### PR TITLE
Bug when trying to play from stopped reload.

### DIFF
--- a/client/js/map.js
+++ b/client/js/map.js
@@ -472,6 +472,11 @@ geoapp.Map = function (arg) {
                 break;
             case 'pause': case 'play': case 'step': case 'stepback':
                 if (!m_animationData) {
+                    if (m_animationOptions &&
+                            m_animationOptions.playState === 'stop') {
+                        m_animationOptions.playState = (
+                            action === 'play' ? action : 'pause');
+                    }
                     this.animate();
                 } else {
                     if (curPlayState === 'stop') {


### PR DESCRIPTION
If you have played an animation and stopped it, then reloaded the web page (or loaded from such a link), and hit play, it would not play the animation.  You needed to hit update first.
