### PR TITLE
Update to follow girder changes and db work.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -311,7 +311,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
                 this.getIntRange(elem, params, field);
                 break;
             default:
-                if (value.length > 0) {
+                if (value !== null && value !== undefined && value.length > 0) {
                     params[field] = elem.val();
                 }
                 break;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -133,22 +133,6 @@ geoapp.parseJSON = function (jsonValue)  {
     }
 };
 
-/* I'd rather use the girder function, but as of girder 1.2.1, the function was
- * defective. */
-geoapp.parseQueryString = function (queryString) {
-    var params = {};
-    if (queryString) {
-        _.each(queryString.replace(/\+/g, ' ').split(/&/g), function (el, i) {
-            var aux = el.split('='), o = {}, val;
-            if (aux.length > 1) {
-                val = decodeURIComponent(el.substr(aux[0].length + 1));
-            }
-            params[decodeURIComponent(aux[0])] = val;
-        });
-    }
-    return params;
-};
-
 /* Run this when everything else is loaded */
 $(function () {
     girder.apiRoot = 'api/v1';

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -13,8 +13,9 @@
             label(for="ga-source") Data Source
             select#ga-source.form-control.input-sm(title="Database source",
                 taxifield="source")
-              option(value="mongo") Mongo 1/12
               option(value="mongo12") Mongo 1/12 Compact
+              option(value="mongo12r") Mongo 1/12 Randomized
+              option(value="mongo") Mongo 1/12
               option(value="mongofull") Mongo Full Data
               option(value="tangelo") Tangelo Service 1/12
           .form-group

--- a/server/taxi.py
+++ b/server/taxi.py
@@ -110,7 +110,7 @@ class TaxiViaMongo():
                        which are inclusive and exclusive respectively.
         :param limit: default limit for the data.
         :param offset: default offset for the data.
-        :param sort: a tuple of the form (key, direction).
+        :param sort: a list of tuples of the form (key, direction).
         :param fields: a list of fields to return, or None for all fields.
         :returns: a dictionary of results.
         """
@@ -226,7 +226,7 @@ class TaxiViaMongoCompact(TaxiViaMongo):
                        which are inclusive and exclusive respectively.
         :param limit: default limit for the data.
         :param offset: default offset for the data.
-        :param sort: a tuple of the form (key, direction).
+        :param sort: a list of tuples of the form (key, direction).
         :param fields: a list of fields to return, or None for all fields.
         :returns: a dictionary of results.
         """
@@ -291,6 +291,17 @@ class TaxiViaMongoCompact(TaxiViaMongo):
             return int((dateutil.parser.parse(value) - self.epoch)
                        .total_seconds() * 1000)
         return value
+
+
+class TaxiViaMongoRandomized(TaxiViaMongoCompact):
+    def find(self, params={}, limit=50, offset=0, sort=None, fields=None):
+        if not sort:
+            sort = [('_id', 1)]
+        elif sort[0][0] == 'random':
+            sort[0] = ('_id', 1)
+        sort = [('_id', 1)]
+        return TaxiViaMongoCompact.find(self, params, limit, offset, sort,
+                                        fields)
 
 
 class TaxiViaTangeloService():
@@ -358,6 +369,8 @@ class Taxi(girder.api.rest.Resource):
             'mongo': (TaxiViaMongo, {}),
             'mongo12': (TaxiViaMongoCompact, {
                 'dbUri': 'mongodb://parakon:27017/taxi12'}),
+            'mongo12r': (TaxiViaMongoRandomized, {
+                'dbUri': 'mongodb://parakon:27017/taxi12r'}),
             'mongofull': (TaxiViaMongoCompact, {
                 'dbUri': 'mongodb://parakon:27017/taxifull'}),
             'tangelo': (TaxiViaTangeloService, {}),


### PR DESCRIPTION
Remove parseQueryString now that it is in girder 1.2.2.  Add the 'randomized' mongo database.
