### PR TITLE
Using browser navigation would break the map.

### DIFF
--- a/client/static/index.html
+++ b/client/static/index.html
@@ -29,6 +29,7 @@
         <script src="${staticRoot}/libs.min.js"></script>
         <script src="${staticRoot}/main.min.js"></script>
         <script src="${staticRoot}/app.min.js"></script>
-        <div id='app-container'/>
+        <div id='ga-main-map'></div>
+        <div id='app-container'></div>
     </body>
 </html>

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -1,4 +1,3 @@
-#ga-main-map
 #ga-main-page
   .panel-group#ga-filter-settings-panel
     .panel.panel-default


### PR DESCRIPTION
The map was getting cleared and not recreated on internal navigation.  It needs to be outside of the div that gets replaced on navigation.

<!---
@huboard:{"order":6.0,"milestone_order":20,"custom_state":""}
-->
