### PR TITLE
Track map extents.

### DIFF
--- a/client/js/activityLog.js
+++ b/client/js/activityLog.js
@@ -33,6 +33,7 @@
         input_change:    {wf: 'WF_EXPLORE', desc: 'text input field changed'},
         link_click:      {wf: 'WF_EXPLORE', desc: 'click on a link'},
         load_data:       {wf: 'WF_GETDATA', desc: 'loaded new data'},
+        map_moved:       {wf: 'WF_EXPLORE', desc: 'map pan, zoom, or resize'},
         navigate:        {wf: 'WF_EXPLORE', desc: 'browser navigation change'},
         select_change:   {wf: 'WF_EXPLORE', desc: 'select box changed'},
         show_tooltip:    {wf: 'WF_EXPLORE', desc: 'show tooltip'},
@@ -44,30 +45,6 @@
             name: 'slide_stop'
         }
     };
-
-    if (window.activityLogger) {
-        /* jshint -W055 */
-        logger = new activityLogger($('body').attr('staticRoot') +
-                                    '/draper.activity_worker-2.1.1.js')
-            .testing(false)
-            .echo(false);
-        logger.registerActivityLogger('http://parakon:9000', 'geoapp',
-                                      geoapp.version);
-        var origInit = geoapp.View.prototype.initialize;
-        geoapp.View.prototype.initialize = function () {
-            origInit.apply(this, arguments);
-            geoapp.activityLog.logControls($(this.el).children(),
-                                           $(this.el).children().attr('id'));
-        };
-        geoapp.router.on('route', function (route, params) {
-            if (params.length) {
-                params = params.slice(-1)[0];
-            }
-            geoapp.activityLog.logActivity('navigate', {
-                route: route, params: params
-            });
-        });
-    }
 
     geoapp.activityLog = {
         /* Log user activity with appropriate workflow information.
@@ -183,4 +160,38 @@
             /* Add pan and zoom support here */
         }
     };
+
+    if (window.activityLogger) {
+        /* jshint -W055 */
+        logger = new activityLogger($('body').attr('staticRoot') +
+                                    '/draper.activity_worker-2.1.1.js')
+            .testing(false)
+            .echo(false);
+        logger.registerActivityLogger('http://parakon:9000', 'geoapp',
+                                      geoapp.version);
+        var origInit = geoapp.View.prototype.initialize;
+        geoapp.View.prototype.initialize = function () {
+            origInit.apply(this, arguments);
+            geoapp.activityLog.logControls($(this.el).children(),
+                                           $(this.el).children().attr('id'));
+        };
+        geoapp.router.on('route', function (route, params) {
+            if (params.length) {
+                params = params.slice(-1)[0];
+            }
+            geoapp.activityLog.logActivity('navigate', {
+                route: route, params: params
+            });
+        });
+        geoapp.activityLog.logSystem('Starting application', {
+            userAgent: navigator.userAgent,
+            browserData: {
+                screenSize: {width: screen.width, height: screen.height},
+                windowSize: {
+                    width: $(window).width(),
+                    height: $(window).height()
+                }
+            }
+        });
+    }
 })();

--- a/client/js/activityLog.js
+++ b/client/js/activityLog.js
@@ -157,7 +157,6 @@
                         value: $(this).val()
                     });
                 });
-            /* Add pan and zoom support here */
         }
     };
 

--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -16,9 +16,11 @@
 geoapp.views.ControlsView = geoapp.View.extend({
     events: {
         'click #ga-controls-filter': function () {
+            $('#ga-controls-filter').removeClass('btn-needed');
             this.updateView(true, 'filter');
         },
         'click #ga-anim-update': function () {
+            $('#ga-anim-update').removeClass('btn-needed');
             if ($('#ga-play').val() === 'stop') {
                 $('#ga-play').val('play');
             }
@@ -26,6 +28,13 @@ geoapp.views.ControlsView = geoapp.View.extend({
         },
         'change #ga-display-settings select': function () {
             this.updateView(true, 'display');
+        },
+        'click .ga-place': function (evt) {
+            var place = $(evt.currentTarget).attr('data-place');
+            if (geoapp.placeList[place]) {
+                geoapp.map.fitBounds(geoapp.placeList[place], 1000);
+                geoapp.map.mapMovedEvent(null, true);
+            }
         },
         'click #ga-play': function () {
             this.animationAction('playpause');
@@ -47,6 +56,12 @@ geoapp.views.ControlsView = geoapp.View.extend({
         },
         'slideStop #ga-step-slider': function (evt) {
             this.animationAction('jump', evt.value);
+        },
+        'change #ga-filter-settings input[type="text"]:visible,#ga-filter-settings select:visible': function (evt) {
+            $('#ga-controls-filter').addClass('btn-needed');
+        },
+        'change #ga-anim-settings input[type="text"]:visible,#ga-anim-settings select:visible': function (evt) {
+            $('#ga-anim-update').addClass('btn-needed');
         }
     },
 
@@ -68,6 +83,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
         this.firstRender = true;
         this.render();
         geoapp.View.prototype.initialize.apply(this, arguments);
+        geoapp.map.fitBounds(geoapp.parseQueryString(settings.map), 0);
     },
 
     /* Reinitialize the view.  This is called if we route to this view while
@@ -92,6 +108,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
             });
         });
         view.updateView(false, update);
+        geoapp.map.fitBounds(geoapp.parseQueryString(settings.map), 1000);
     },
 
     /* Render the view.  This also prepares various controls if this is the
@@ -103,7 +120,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
         )).on('ready.geoapp.view', function () {
             update = false;
             if (view.initialSettings && !view.usedInitialSettings) {
-                settings = view.initialSettings;
+                var settings = view.initialSettings;
                 view.usedInitialSettings = true;
                 _.each(view.controlSections, function (baseSelector, section) {
                     if (settings[section]) {
@@ -421,6 +438,21 @@ geoapp.views.ControlsView = geoapp.View.extend({
             'mapview', 'anim', {'ga-play': playState}, true);
     }
 });
+
+geoapp.placeList = {
+    manhattan: {
+        x0: -74.0276489,
+        y0:  40.8304859,
+        x1: -73.9161453,
+        y1:  40.6877773
+    },
+    timessq: {
+        x0: -74.0048904,
+        y0:  40.7687378,
+        x1: -73.9708862,
+        y1:  40.7435085
+    }
+};
 
 /* Given an appropriate route, redirect to the ControlsView.
  *

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -15,6 +15,7 @@
 
 var geoapp = girder;
 var app;
+var m_lastUpdateNavigationSection;
 
 moment.suppressDeprecationWarnings = true;
 
@@ -100,8 +101,11 @@ geoapp.router.off('route').on('route', function (route, params) {
  * @param params: a dictionary to encode.
  * @param modify: if true, modify existing parameters.  Otherwise, the
  *                specified section is replaced with the new parameters.
+ * @param combine: if true and the last call to updateNavigation was the same
+ *                 section, replace the previous navigation rather than adding
+ *                 to the history.
  */
-geoapp.updateNavigation = function (base, section, params, modify) {
+geoapp.updateNavigation = function (base, section, params, modify, combine) {
     var curRoute = Backbone.history.fragment || '',
         routeParts = geoapp.dialogs.splitRoute(curRoute),
         queryString = geoapp.parseQueryString(routeParts.name);
@@ -122,7 +126,11 @@ geoapp.updateNavigation = function (base, section, params, modify) {
     if (unparsedQueryString.length > 0) {
         unparsedQueryString = '?' + unparsedQueryString;
     }
-    geoapp.router.navigate(base + unparsedQueryString);
+    if (section !== m_lastUpdateNavigationSection) {
+        combine = false;
+    }
+    m_lastUpdateNavigationSection = section;
+    geoapp.router.navigate(base + unparsedQueryString, {replace: combine});
 };
 
 /* Parse a JSON string to an object, returning an empty object on any error.

--- a/client/stylesheets/main.styl
+++ b/client/stylesheets/main.styl
@@ -66,6 +66,23 @@ a
       display none
     &[value=play] span.canpause
       display inherit
+  .animate-spin
+    animation spin 3s infinite linear
+  #ga-map-loading
+    font-size 20px
+    line-height 1em
+    display inline-block
+    position relative
+    top 5px
+    left 4px
+  .btn-needed
+    color black
+    background-color #40e040
+    border-color black
+  .btn-needed:hover,.btn-needed:focus,.btn-needed.focus,.btn-needed:active,.btn-needed.active
+    background-color #39ac39
+  .ga-place
+    padding 1px 4px 1px 0px
 
 .daterangepicker
   .ranges

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -49,17 +49,12 @@
               type="text", placeholder="# - #",
               title="Number of passengers",
               taxifield="passenger_count", taxitype="intRange")
-          //
-            .form-group
-              label(for="ga-random") Random Selector
-              input#ga-random.form-control.input-sm(
-                type="text", placeholder="#.### - #.###",
-                title="Random Selector",
-                taxifield="random", taxitype="floatRange")
           .form-group
             button#ga-controls-filter.btn.btn-default.btn-sm
               i.icon-ok
               |  Filter
+            #ga-map-loading.hidden
+              i.icon-spin1.animate-spin
   .panel-group#ga-display-settings-panel
     .panel.panel-default
       .panel-heading
@@ -86,6 +81,15 @@
               option(value="mapquest") MapQuest tiles
               option(value="openstreetmap") OpenStreetMap
               option(value="tonerlite") Stamen Toner Lite
+          .form-group
+            button#ga-place-manhattan.btn.btn-sm.ga-place(
+                data-place="manhattan", title="Show all of Manhattan") 
+              i.icon-target
+              |  Manhattan
+            button#ga-place-timessq.btn.btn-sm.ga-place(
+                data-place="timessq", title="Show Times Square")
+              i.icon-target
+              |  Times Sq.
   .panel-group#ga-anim-settings-panel
     .panel.panel-default
       .panel-heading


### PR DESCRIPTION
Track map extents, use them for routing, and provide some presets.  Report map pan, zoom, and resize to the activity logger (but not too often).

Added a loading spinner and mark when filters or animation values are dirty.

Log when the application starts.

Updated reference to geojs.

This completes issue #31.
