### PR TITLE
Add Green taxi database.

### DIFF
--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -15,6 +15,7 @@
             select#ga-source.form-control.input-sm(title="Database source",
                 taxifield="source")
               option(value="postgresfull") Postgres Full Shuffled
+              option(value="postgresfullg") Postgres Full w/ Green
               option(value="postgres12") Postgres 1/12 Shuffled
               option(value="mongofull") Mongo Full Shuffled
               option(value="mongo12r") Mongo 1/12 Shuffled


### PR DESCRIPTION
I'm testing how performance is affected if I store dates in epoch seconds rather than epoch milliseconds for postgres.  This uses less space.  It is is no slower, it will be worth switching.

Regarding speed, this seems to be trivially faster than using epoch milliseconds, so the virtue is the space savings (40.8 Gb rather than 42.8 Gb).
