### PR TITLE
Use triangles not sprites for point rendering.

### DIFF
--- a/client/js/map.js
+++ b/client/js/map.js
@@ -65,8 +65,8 @@ geoapp.Map = function (arg) {
         m_maxVectorScale = 5, /* Increase vector sizes */
         m_verbose = 1;
 
-    this.maximumMapPoints = 100000;
-    this.maximumVectors = 50000;
+    this.maximumMapPoints = 20000; //100000;
+    this.maximumVectors = 15000; //50000;
     /* maximumDataPoints defaults to the maximum of maximumMapPoints and
      * maximumVectors */
     this.maximumDataPoints = null;
@@ -74,7 +74,7 @@ geoapp.Map = function (arg) {
      * maximumDataPoints).  If oneSmallPage is true, pageDataPoints are loaded,
      * then all of the rest of the data in a second query.  If false,
      * pageDataPoints are loaded at a time until all of the data is loaded. */
-    this.pageDataPoints = 10000;
+    this.pageDataPoints = 5000; //10000;
     this.oneSmallPage = true;
 
     /* Show a map with data.  If we have already shown the map, just update

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -117,7 +117,7 @@ geoapp.Map = function (arg) {
                 renderer: 'vgl'
             });
             m_geoPoints = geoLayer.createFeature('point', {
-                primitiveShape: 'sprite',
+                primitiveShape: 'triangle',
                 selectionAPI: false,
                 dynamicDraw: true
             });


### PR DESCRIPTION
Apparently, the true key to the MacBook speed issue is using triangles for rendering points rather than GL_POINTS (the 'sprite' option).  This means 1/3 as many points can be loaded, and, in the ideal case, we would measure the performance and pick the sprites when they work to be faster and use less memory when it works as well.  For now, just switch back to triangles.

Also, reduced the number of points loaded by default.
