### PR TITLE
Added controls to toggle data layers.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -30,9 +30,10 @@ geoapp.views.ControlsView = geoapp.View.extend({
             }
             this.updateView(true, 'anim');
         },
-        'change #ga-display-settings select,#ga-display-settings input[type="text"]': function () {
+        'change #ga-display-settings select,#ga-display-settings input[type="text"],#ga-display-settings input[type="checkbox"]': function (evt) {
             $('#ga-display-update').removeClass('btn-needed');
-            this.updateView(true, 'display');
+            var combineNav = $(evt.target).is('.ga-slider-ctl');
+            this.updateView(combineNav ? 'combine' : true, 'display');
         },
         'click #ga-display-update': function () {
             $('#ga-display-update').removeClass('btn-needed');
@@ -328,12 +329,14 @@ geoapp.views.ControlsView = geoapp.View.extend({
     /* Update some portion of the view.  This parses the specified section,
      * and, if appropriate, updates the map or other details.
      *
-     * @param updateNav: true to update the navigation route.
+     * @param updateNav: true to update the navigation route.  'combine' to
+     *                   combine updates to the navigation route if the section
+     *                   is the same as the last changed.
      * @param updateSection: falsy to update all sections, a string to update
      *                       just one section, or an object with the keys which
      *                       have thuthy values are the sections to update.
      */
-    updateView: function (updateNav, updateSection) {
+    updateView: function (updateNav, updateSection, combineNav) {
         var results = {}, params;
         if (updateSection && $.type(updateSection) === 'string') {
             var sections = {};
@@ -402,7 +405,9 @@ geoapp.views.ControlsView = geoapp.View.extend({
      *
      * @param section: the name of the section to update.  One of
      *                 'taxi-filter', 'instagram-filter', 'anim', or 'display'.
-     * @param updateNav: true to update the navigation route.
+     * @param updateNav: true to update the navigation route.  'combine' to
+     *                   combine updates to the navigation route if the section
+     *                   is the same as the last changed.
      * @param returnVav: if true, return all of the navigation fields, even
      *                   blank ones.
      * @return: the new map filter parameters or the complete navigation
@@ -421,7 +426,8 @@ geoapp.views.ControlsView = geoapp.View.extend({
             }
         });
         if (updateNav) {
-            geoapp.updateNavigation('mapview', section, navFields);
+            geoapp.updateNavigation('mapview', section, navFields, undefined,
+                                    updateNav === 'combine');
         }
         if (returnNav) {
             return navFields;
@@ -431,7 +437,9 @@ geoapp.views.ControlsView = geoapp.View.extend({
 
     /* Update values associated with the animation controls.
      *
-     * @param updateNav: true to update the navigation route.
+     * @param updateNav: true to update the navigation route.  'combine' to
+     *                   combine updates to the navigation route if the section
+     *                   is the same as the last changed.
      * @return: the new animation parameters.
      */
     updateAnimValues: function (updateNav, results) {
@@ -483,6 +491,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
         switch (ttype) {
             case 'boolean':
                 params[field] = elem.is(':checked') ? true : false;
+                value = params[field];
                 break;
             case 'dateRange':
                 this.getDateRange(elem, params, field);

--- a/client/js/layers.js
+++ b/client/js/layers.js
@@ -155,7 +155,8 @@ geoapp.mapLayers.taxi = function (map, arg) {
 
     this.paramChangedKeys = [
         'display-type', 'display-process', 'display-num-bins',
-        'display-max-points', 'display-max-lines', 'data-opacity'
+        'display-max-points', 'display-max-lines', 'data-opacity',
+        'show-taxi-data'
     ];
 
     /* Set the map to display pickup or dropoff points.
@@ -592,6 +593,14 @@ geoapp.mapLayers.taxi = function (map, arg) {
      * @param params: the new map parameters.
      */
     this.updateMapParams = function (params) {
+        var data = m_this.data(),
+            visible = (params['show-taxi-data'] !== false && data);
+        m_geoPoints.visible(visible);
+        m_geoLines.visible(visible);
+        m_geoPoly.visible(visible);
+        if (!visible) {
+            return;
+        }
         if (params['display-max-points'] > 0) {
             this.maximumMapPoints = params['display-max-points'];
         }
@@ -797,6 +806,30 @@ geoapp.mapLayers.taxi = function (map, arg) {
                 'strokeOpacity');
         }
     };
+
+    /* Return the current internal state of the layer.
+     *
+     * @param key: the key of the object to fetch, or undefined for a
+     *             dictionary of objects.
+     * @returns: a dictionary of the current state, or one of the internal
+     *           state objects.
+     */
+    this.getInternalState = function (key) {
+        var state = {
+            geoPoints: m_geoPoints,
+            geoLines: m_geoLines,
+            geoPoly: m_geoPoly,
+            pickupOnlyColor: m_pickupOnlyColor,
+            pickupColor: m_pickupColor,
+            dropoffOnlyColor: m_dropoffOnlyColor,
+            dropoffColor: m_dropoffColor,
+            maxVectorScale: m_maxVectorScale
+        };
+        if (key) {
+            return state[key];
+        }
+        return state;
+    };
 };
 
 inherit(geoapp.mapLayers.taxi, geoapp.MapLayer);
@@ -831,7 +864,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
     });
 
     this.paramChangedKeys = [
-        'data-opacity'
+        'data-opacity', 'show-instagram-data'
     ];
 
     /* Update the taxi map based on the map parameters.  Values that are
@@ -841,14 +874,18 @@ geoapp.mapLayers.instagram = function (map, arg) {
      * @param params: the new map parameters.
      */
     this.updateMapParams = function (params) {
+        var data = m_this.data(),
+            visible = (params['show-instagram-data'] !== false && data);
+        m_geoPoints.visible(visible);
+        if (!visible) {
+            return;
+        }
         if (params['display-max-points'] > 0) {
             this.maximumMapPoints = params['display-max-points'];
         }
         if (params['data-opacity'] > 0) {
             params['inst-opacity'] = params['data-opacity'];
         }
-        var data = m_this.data();
-
         data.numPoints = Math.min(data.data.length, this.maximumMapPoints);
         data.x_column = data.columns.longitude;
         data.y_column = data.columns.latitude;
@@ -954,6 +991,25 @@ geoapp.mapLayers.instagram = function (map, arg) {
         }
         m_geoPoints.actors()[0].mapper().updateSourceBuffer(
             'fillOpacity');
+    };
+
+    /* Return the current internal state of the layer.
+     *
+     * @param key: the key of the object to fetch, or undefined for a
+     *             dictionary of objects.
+     * @returns: a dictionary of the current state, or one of the internal
+     *           state objects.
+     */
+    this.getInternalState = function (key) {
+        var state = {
+            geoPoints: m_geoPoints,
+            defaultOpacity: m_defaultOpacity,
+            pointColor: m_pointColor
+        };
+        if (key) {
+            return state[key];
+        }
+        return state;
     };
 };
 

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -94,6 +94,17 @@
             button#ga-display-update.btn.btn-default.btn-sm
               i.icon-cw
               |  Update
+            label Show
+            span(title="Show taxi trip data")
+              input#ga-show-taxi-data.form-control.input-sm(
+                type="checkbox", checked="checked",
+                taxifield="show-taxi-data", taxitype="boolean")
+              label(for="ga-show-taxi-data") Taxi
+            span(title="Show instagram message data")
+              input#ga-show-instagram-data.form-control.input-sm(
+                type="checkbox", checked="checked",
+                taxifield="show-instagram-data", taxitype="boolean")
+              label(for="ga-show-instagram-data") Instagram
           .form-group
             button#ga-place-manhattan.btn.btn-sm.ga-place(
                 data-place="manhattan", title="Show all of Manhattan") 


### PR DESCRIPTION
Fixed an issue recording routing of checkboxes.

When using sliders, don't continually add to the navigation history.

Added some internal debug functions (getInternalState) for different layers.

Don't throw an error if we haven't loaded some data yet.
