### PR TITLE
Highlight instagram points.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,7 +198,7 @@ module.exports = function (grunt) {
                         'geojs/bower_components/proj4/dist/proj4-src.js',
                         'geojs/bower_components/d3/d3.js',
                         'geojs/node_modules/pnltri/pnltri.js',
-                        'geojs/dist/built/geo.min.js',
+                        'geojs/dist/built/geo.js',
                         /* daterangepicker */
                         'node_modules/moment/moment.js',
                         'node_modules/daterangepicker/daterangepicker.js',

--- a/client/js/activityLog.js
+++ b/client/js/activityLog.js
@@ -46,6 +46,16 @@
             desc: 'show date-range picker'},
         input_change:    {elem: 'textbox',  act: 'alter',
             desc: 'text input field changed'},
+        inst_overlay:    {elem: 'map',      act: 'show',
+            desc: 'show instagram overlay'},
+        inst_overlay_hide: {elem: 'map',    act: 'hide',
+            desc: 'hide instagram overlay'},
+        inst_table:      {elem: 'listbox',  act: 'show',
+            desc: 'show instagram table'},
+        inst_table_add:  {elem: 'listbox',  act: 'alter',
+            desc: 'add data to instagram table'},
+        inst_table_hide: {elem: 'listbox',  act: 'hide',
+            desc: 'hide instagram table'},
         link_click:      {elem: 'link',     act: 'select',
             desc: 'click on a link'},
         load_data:       {elem: 'map',      act: 'perform',
@@ -60,6 +70,8 @@
             desc: 'show tooltip'},
         show_view:       {elem: 'window',   act: 'show',
             desc: 'show view'},
+        scroll:          {elem: 'panel',    act: 'alter',
+            desc: 'scroll a region'},
         slide:           {elem: 'slider',   act: 'alter',
             desc: 'move a slider'},
         slideStart:      {elem: 'slider',   act: 'enter', name: 'slide_start',
@@ -90,17 +102,20 @@
                 activity: activity,
                 action: activity,
                 elementType: 'element_type',
+                elementSub: '' + (data.value !== undefined ? data.value : ''),
                 elementGroup: group,
-                elementSub: data.value !== undefined ? data.value : '',
                 source: system ? 'system' : 'user',
+                meta: {
+                    /* Disabling this until I know how it needs to be escaped.
+                     * See email discussion with Dave Reed.
+                    data: data
+                     */
+                },
                 tags: [
                     /* a list of tags to help define some other meaningful
                      * words, such as if this action deals with a 'query' or is
                      * altering 'visual' elements */
-                ],
-                meta: {
-                    data: data
-                }
+                ]
             };
             if (!system) {
                 msg.elementId = data.id;
@@ -220,6 +235,26 @@
                         value: $(this).val()
                     });
                 });
+            $('.al-scroller', selector)
+            .on('scroll', function (evt) {
+                /* log scrolling with a maximum rate and some delay.  This will
+                 * show where the scrolling ended up and prevent swamping the
+                 * log system with scroll events. */
+                var elem = $(this),
+                    id = elem.closest('[id]').attr('id');
+                if (!log.scrollerTimers) {
+                    log.scrollerTimers = {};
+                }
+                if (!log.scrollerTimers[id]) {
+                    log.scrollerTimers[id] = window.setTimeout(function () {
+                        log.scrollerTimers[id] = null;
+                        log.logActivity('scroll', 'controls', {
+                            id: id,
+                            value: elem.scrollTop() || elem.scrollLeft()
+                        });
+                    }, 333);
+                }
+            });
         }
     };
 

--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -75,6 +75,34 @@ geoapp.views.ControlsView = geoapp.View.extend({
         },
         'change #ga-anim-settings input[type="text"]:visible,#ga-anim-settings select:visible': function (evt) {
             $('#ga-anim-update').addClass('btn-needed');
+        },
+        'keydown #ga-taxi-filter-settings input[type="text"]': function (evt) {
+            if (evt.which === 13) {
+                window.setTimeout(function () {
+                    $('#ga-taxi-filter').click();
+                }, 10);
+            }
+        },
+        'keydown #ga-instagram-filter-settings input[type="text"]': function (evt) {
+            if (evt.which === 13) {
+                window.setTimeout(function () {
+                    $('#ga-instagram-filter').click();
+                }, 10);
+            }
+        },
+        'keydown #ga-display-settings input[type="text"]': function (evt) {
+            if (evt.which === 13) {
+                window.setTimeout(function () {
+                    $('#ga-display-update').click();
+                }, 10);
+            }
+        },
+        'keydown #ga-anim-settings input[type="text"]': function (evt) {
+            if (evt.which === 13) {
+                window.setTimeout(function () {
+                    $('#ga-anim-update').click();
+                }, 10);
+            }
         }
     },
 
@@ -196,7 +224,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
                     timePickerIncrement: 5
                 });
             });
-            $('[title]').tooltip();
+            $('[title]').tooltip({delay: {show: 250}});
             $('#ga-step-slider').slider({
                 focus: true,
                 formatter: geoapp.map.getStepDescription

--- a/client/js/datahandler.js
+++ b/client/js/datahandler.js
@@ -278,6 +278,8 @@ geoapp.dataHandlers.instagram = function (arg) {
     arg = arg || {};
     geoapp.DataHandler.call(this, arg);
 
+    var m_this = this;
+
     this.datakey = datakey;
 
     /* Replace or add to the instagram data used for the current map.
@@ -381,8 +383,9 @@ geoapp.dataHandlers.instagram = function (arg) {
                 })
                 .append($('<td/>').text(moment(data.data[i][date_column])
                     .format('YY-MM-DD HH:mm')))
-                .append($('<td/>').text(data.data[i][caption_column])
-                    .attr('title', data.data[i][caption_column]))
+                .append($('<td/>').text(data.data[i][caption_column]))
+                /* Don't add a tooltip, since we pop up the photo elsewhere */
+                //  .attr('title', data.data[i][caption_column]))
             );
         }
         if (current + page < data.data.length) {
@@ -393,10 +396,29 @@ geoapp.dataHandlers.instagram = function (arg) {
                 colspan: 2
             }).text('More ...')));
         }
-        //TODO:: switch to a bootstrap tooltip with the picture and caption,
-        // highlight the point hovered over, zoom to that point if clicked,
-        // sort data table by date, inverse date, or original
+        /* If hovering over a row, show the relevant instagram point */
+        $('tr', table).off('.instagram-table'
+        ).on('mouseleave.instagram-table', function (evt) {
+            layer.setCurrentPoint(null);
+        }).on('mouseenter.instagram-table', this.instagramTableHighlight
+        );
+        //TODO:: highlight the point hovered over, zoom to that point if
+        // clicked, sort data table by date, inverse date, or original
         return moreData;
+    };
+
+    /* Highlight the hovered over row.
+     *
+     * @param evt: the event that triggered this call.
+     */
+    this.instagramTableHighlight = function (evt) {
+        var layer = geoapp.map.getLayer(m_this.datakey),
+            idx = $(evt.currentTarget).attr('item');
+        if (idx === '') {
+            layer.setCurrentPoint(null);
+            return;
+        }
+        layer.setCurrentPoint(parseInt(idx));
     };
 };
 

--- a/client/js/datahandler.js
+++ b/client/js/datahandler.js
@@ -140,7 +140,7 @@ geoapp.DataHandler = function (arg) {
             options.params.offset += resp.datacount;
         }
         loadfunc.call(this, options, callNext, moreData);
-        geoapp.activityLog.logActivity('load_data', 'datahandler', {
+        geoapp.activityLog.logSystem('load_data', 'datahandler', {
             data: options.description,
             params: options.params,
             complete: !callNext
@@ -321,6 +321,10 @@ geoapp.dataHandlers.instagram = function (arg) {
         /* Hide the instagram results panel if there is no data.  Show it with
          * a small quantity of data if there is data. */
         if (!options.data || !options.data.data || !options.data.data.length) {
+            if (!$('#ga-instagram-results-panel').hadClass('hidden')) {
+                geoapp.activityLog.logSystem(
+                    'inst_table_hide', 'datahandler', {});
+            }
             $('#ga-instagram-results-panel').addClass('hidden');
             return;
         }
@@ -368,7 +372,7 @@ geoapp.dataHandlers.instagram = function (arg) {
         if (!data || !data.data || !data.data.length) {
             return moreData;
         }
-        var current = $('tr:has(td)', table).length;
+        var current = $('tr[item]', table).length;
         var date_column = data.columns.posted_date,
             caption_column = data.columns.caption,
             url_column = data.columns.url;
@@ -388,6 +392,8 @@ geoapp.dataHandlers.instagram = function (arg) {
                 //  .attr('title', data.data[i][caption_column]))
             );
         }
+        geoapp.activityLog.logSystem(
+            !current ? 'inst_table' : 'inst_table_add', 'datahandler', {});
         if (current + page < data.data.length) {
             moreData = true;
             table.append($('<tr/>').attr({
@@ -402,8 +408,8 @@ geoapp.dataHandlers.instagram = function (arg) {
             layer.setCurrentPoint(null);
         }).on('mouseenter.instagram-table', this.instagramTableHighlight
         );
-        //TODO:: highlight the point hovered over, zoom to that point if
-        // clicked, sort data table by date, inverse date, or original
+        //TODO:: zoom to that point if clicked, sort data table by date,
+        // inverse date, or original
         return moreData;
     };
 
@@ -418,7 +424,7 @@ geoapp.dataHandlers.instagram = function (arg) {
             layer.setCurrentPoint(null);
             return;
         }
-        layer.setCurrentPoint(parseInt(idx));
+        layer.setCurrentPoint(parseInt(idx), undefined, undefined, 'table');
     };
 };
 

--- a/client/js/layers.js
+++ b/client/js/layers.js
@@ -1136,6 +1136,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
             }),
             offset = 10,
             url = item[mapData.columns.image_url],
+            imageUrl,
             caption = item[mapData.columns.caption] || '',
             date = moment(item[mapData.columns.posted_date]).format(
                 'MM-DD HH:mm');
@@ -1180,6 +1181,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
                 m_this.setCurrentPoint(null, true, true);
             }, 500);
         });
+        imageUrl = url.replace(/\/$/, '') + '/media?size=m';
         if ($('img', overlay).attr('orig_url') !== url) {
             $('img', overlay).off('.instagram-overlay'
             ).on('load.instagram-overlay', function () {
@@ -1188,7 +1190,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
             }).on('error.instagram-overlay', function () {
                 $('img', overlay).css('display', 'none');
                 overlay.css('display', 'block');
-            }).attr({src: url + '/media?size=m', orig_url: url});
+            }).attr({src: imageUrl, orig_url: url});
         } else {
             overlay.css('display', 'block');
         }

--- a/client/js/layers.js
+++ b/client/js/layers.js
@@ -848,9 +848,14 @@ geoapp.mapLayers.instagram = function (map, arg) {
 
     var m_this = this,
         m_geoPoints,
+        m_overlayTimer,
+        m_mapEventsSet,
 
         m_defaultOpacity = 0.1,
-        m_pointColor = geo.util.convertColor('#FF0000');
+        m_pointColor = geo.util.convertColor('#FF0000'),
+        m_strokeColor = geo.util.convertColor('#E69F00');
+
+    this.currentPoint = null;
 
     var geoLayer;
 
@@ -859,7 +864,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
     });
     m_geoPoints = geoLayer.createFeature('point', {
         primitiveShape: 'triangle',
-        selectionAPI: false,
+        selectionAPI: true,
         dynamicDraw: true
     });
 
@@ -897,6 +902,9 @@ geoapp.mapLayers.instagram = function (map, arg) {
         .style({
             fillColor: m_pointColor,
             fillOpacity: params['inst-opacity'] || m_defaultOpacity,
+            strokeColor: m_strokeColor,
+            strokeOpacity: 1,
+            strokeWidth: 5,
             stroke: false,
             radius: 5
         })
@@ -905,7 +913,16 @@ geoapp.mapLayers.instagram = function (map, arg) {
                 x: d[data.x_column],
                 y: d[data.y_column]
             };
+        })
+        .geoOff(geo.event.feature.mouseover)
+        .geoOn(geo.event.feature.mouseover, function (evt) {
+            m_this.highlightPoint(evt.index, evt, true);
+        })
+        .geoOff(geo.event.feature.mouseout)
+        .geoOn(geo.event.feature.mouseout, function (evt) {
+            m_this.highlightPoint(evt.index, evt, false);
         });
+        this.setCurrentPoint(null, false);
     };
 
     /* Return the index of the date column for this data.
@@ -962,8 +979,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
             i, j, v, bin, opac, vis, vpf;
 
         vpf = m_geoPoints.verticesPerFeature();
-        opac = m_geoPoints.actors()[0].mapper().getSourceBuffer(
-            'fillOpacity');
+        opac = m_geoPoints.actors()[0].mapper().getSourceBuffer('fillOpacity');
         for (i = 0, v = 0; i < mapData.numPoints; i += 1) {
             vis = this.inAnimationBin(
                 dataBin[i], options.numBins, options.step,
@@ -984,8 +1000,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
             vpf, opac, v;
 
         vpf = m_geoPoints.verticesPerFeature();
-        opac = m_geoPoints.actors()[0].mapper().getSourceBuffer(
-            'fillOpacity');
+        opac = m_geoPoints.actors()[0].mapper().getSourceBuffer('fillOpacity');
         for (v = 0; v < mapData.numPoints * vpf; v += 1) {
             opac[v] = mapParams['inst-opacity'] || m_defaultOpacity;
         }
@@ -1010,6 +1025,173 @@ geoapp.mapLayers.instagram = function (map, arg) {
             return state[key];
         }
         return state;
+    };
+
+    /* When the mouse hovers above a point on the map, indicate this.
+     *
+     * @param idx: 0-based index in the data array.
+     * @param evt: the event that triggered this call.
+     * @param over: true if the mouse if over the point, false if it just left.
+     */
+    this.highlightPoint = function (idx, evt, over) {
+        var vpf = m_geoPoints.verticesPerFeature(),
+            cur = null,
+            opac;
+        if (over) {
+            opac = m_geoPoints.actors()[0].mapper().getSourceBuffer(
+                'fillOpacity');
+            if (idx * vpf >= opac.length || !opac[idx * vpf]) {
+                over = false;
+            }
+        }
+        if (!this.inPoints) {
+            this.inPoints = {top: [], other: []};
+        }
+        if ((!over || !evt.top) && $.inArray(idx, this.inPoints.top) >= 0) {
+            this.inPoints.top.splice($.inArray(idx, this.inPoints.top), 1);
+        }
+        if ((!over || evt.top) && $.inArray(idx, this.inPoints.other) >= 0) {
+            this.inPoints.other.splice($.inArray(idx, this.inPoints.other), 1);
+        }
+        if (over && evt.top && $.inArray(idx, this.inPoints.top) < 0) {
+            this.inPoints.top.push(idx);
+        }
+        if (over && !evt.top && $.inArray(idx, this.inPoints.other) < 0) {
+            this.inPoints.other.push(idx);
+        }
+        if (this.inPoints.top.length) {
+            cur = this.inPoints.top[0];
+        } else if (this.inPoints.other.length) {
+            cur = this.inPoints.other[0];
+        }
+        this.setCurrentPoint(cur);
+    };
+
+    /* Set a point as the current point.  Mark it as the current point and set
+     * a timer to display the instagram picture soon.
+     *
+     * @param cur: the 0-based point index, or null to clear the current point.
+     * @param redraw: if false, don't redraw the map.  If true, always update.
+     * @param immediate: if true, show or hide the overlay immediately.
+     */
+    this.setCurrentPoint = function (cur, redraw, immediate) {
+        if (cur === this.currentPoint && redraw !== true) {
+            return;
+        }
+        var vpf = m_geoPoints.verticesPerFeature(),
+            stroke, i, old = this.currentPoint;
+
+        stroke = m_geoPoints.actors()[0].mapper().getSourceBuffer('stroke');
+        for (i = 0; i < vpf; i += 1) {
+            if (old !== null && old * vpf < stroke.length) {
+                stroke[old * vpf + i] = 0;
+            }
+            if (cur !== null && cur * vpf < stroke.length) {
+                stroke[cur * vpf + i] = 1;
+            }
+        }
+        m_geoPoints.actors()[0].mapper().updateSourceBuffer('stroke');
+        if (redraw !== false) {
+            this.map.triggerDraw();
+        }
+        this.currentPoint = cur;
+        /* If no point is selected, use a shorter timeout for the overlay. */
+        var delay = !cur ? 125 : 250;
+        if (m_overlayTimer) {
+            window.clearTimeout(m_overlayTimer);
+            m_overlayTimer = null;
+        }
+        if (!immediate) {
+            m_overlayTimer = window.setTimeout(this.showOverlay, delay);
+        } else {
+            this.showOverlay();
+        }
+        if (cur && !m_mapEventsSet && $('#ga-main-map').length) {
+            $('#ga-main-map').on('mouseleave', function () {
+                m_this.setCurrentPoint(null);
+            });
+            m_mapEventsSet = true;
+        }
+    };
+
+    /* Show or hide the overlay based on the current point.  If the current
+     * point is off the screen, show the overlay as close to that point as we
+     * can.
+     */
+    this.showOverlay = function () {
+        m_overlayTimer = null;
+        var mapData = m_this.data(),
+            overlay = $('#ga-instagram-overlay');
+        if (m_this.currentPoint === null || !mapData.data ||
+                m_this.currentPoint >= mapData.data.length) {
+            overlay.css('display', 'none');
+            return;
+        }
+        var item = mapData.data[m_this.currentPoint];
+        var mapW = $('#ga-main-map').width(),
+            mapH = $('#ga-main-map').height(),
+            pos = m_this.map.getMap().gcsToDisplay({
+                x: item[mapData.columns.longitude],
+                y: item[mapData.columns.latitude]
+            }),
+            offset = 10,
+            url = item[mapData.columns.image_url],
+            caption = item[mapData.columns.caption] || '',
+            date = moment(item[mapData.columns.posted_date]).format(
+                'MM-DD HH:mm');
+        $('.ga-instagram-overlay-date', overlay).text(date).attr('title', date);
+        $('.ga-instagram-overlay-caption', overlay).text(caption).attr(
+            'title', caption);
+        $('.ga-instagram-overlay-link a', overlay).text(url).attr(
+            'href', url);
+        if (pos.x >= 0 && pos.y >= 0 && pos.x <= mapW && pos.y <= mapH) {
+            $('.ga-instagram-overlay-arrow', overlay).css('display', 'none');
+        } else {
+            var dx = 0, dy = 0;
+            /* jscs:disable requireBlocksOnNewline */
+            if (pos.x < 0) {    dx = pos.x;         pos.x = 0; }
+            if (pos.x > mapW) { dx = pos.x - mapW;  pos.x = mapW; }
+            if (pos.y < 0) {    dy = pos.y;         pos.y = 0; }
+            if (pos.y > mapH) { dy = pos.y - mapH;  pos.y = mapH; }
+            /* jscs:enable requireBlocksOnNewline */
+            $('.ga-instagram-overlay-arrow', overlay).css({
+                display: 'block',
+                transform: 'rotate(' + Math.atan2(dy, dx).toFixed(3) + 'rad)'
+            });
+            offset = 0;
+        }
+        // clamp position to the screen, so that the overlay is always on
+        // screen.  Possibly also we should avoid overlaying on top of our
+        // controls.
+        overlay.css({
+            left: pos.x <= mapW / 2 ? (pos.x + offset) + 'px' : '',
+            right: pos.x <= mapW / 2 ? '' : (mapW - pos.x + offset) + 'px',
+            top: pos.y <= mapH / 2 ? (pos.y + offset) + 'px' : '',
+            bottom: pos.y <= mapH / 2 ? '' : (mapH - pos.y + offset) + 'px',
+            display: 'none'
+        }).off('.instagram-overlay'
+        ).on('mouseenter.instagram-overlay', function () {
+            if (m_overlayTimer) {
+                window.clearTimeout(m_overlayTimer);
+                m_overlayTimer = null;
+            }
+        }).on('mouseleave.instagram-overlay', function () {
+            m_overlayTimer = window.setTimeout(function () {
+                m_this.setCurrentPoint(null, true, true);
+            }, 500);
+        });
+        if ($('img', overlay).attr('orig_url') !== url) {
+            $('img', overlay).off('.instagram-overlay'
+            ).on('load.instagram-overlay', function () {
+                $('img', overlay).css('display', 'block');
+                overlay.css('display', 'block');
+            }).on('error.instagram-overlay', function () {
+                $('img', overlay).css('display', 'none');
+                overlay.css('display', 'block');
+            }).attr({src: url + '/media?size=m', orig_url: url});
+        } else {
+            overlay.css('display', 'block');
+        }
     };
 };
 

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -375,7 +375,7 @@ geoapp.Map = function (arg) {
             m_drawQueued = false;
             m_drawTimer = window.setTimeout(function () {
                 view.triggerDraw(true);
-            }, 100);
+            }, 33);
             return;
         } else {
             m_drawQueued = true;

--- a/client/stylesheets/main.styl
+++ b/client/stylesheets/main.styl
@@ -5,7 +5,7 @@ html, body
   overflow hidden
 
 *
-  font-family 'Droid Sans',sans-serif
+  font-family 'Droid Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','NotoColorEmoji','Segoe UI Symbol','Android Emoji','EmojiSymbols'
   font-smoothing antialiased
 
 body
@@ -33,6 +33,7 @@ a
   z-index 1
 
 .ga-main-ui,.ga-results-ui
+  user-select none
   position absolute
   .panel
     background none
@@ -147,6 +148,8 @@ a
     padding-left 10px
     line-height 1.2em
     margin-top 1px
+  #ga-cycle-anim,.ga-data-loaded
+    user-select text
 
 .ga-results-ui
   right 0
@@ -162,6 +165,7 @@ a
         background rgba(232, 255, 255, 0.75)
         color black
         td
+          user-select text
           overflow hidden
           white-space nowrap
           max-width 350px
@@ -196,3 +200,44 @@ a
   max-width 205px
   white-space nowrap
   overflow hidden
+
+#ga-instagram-overlay
+  display none
+  position fixed
+  z-index 2
+  border 4px solid #AAA
+  border-radius 3px
+  background #AAA
+  font-size 12px
+  color black
+  box-sizing content-box
+  width 225px
+  .ga-instagram-overlay-image img
+    height 225px
+    width 100%
+  .ga-instagram-overlay-text
+    width 100%
+    max-height 56px
+    line-height 16px
+    overflow hidden
+    word-wrap break-word
+    white-space normal
+  .ga-instagram-overlay-date
+    padding-right 5px
+    font-weight bold
+    color #333
+  .ga-instagram-overlay-link a
+    color #214565
+    overflow hidden
+    white-space nowrap
+    text-overflow ellipsis
+    width 100%
+    display block
+    padding-top 3px
+  .ga-instagram-overlay-arrow
+    display none
+    float right
+    font-size 24px
+    transform rotate(0deg)
+
+

--- a/client/templates/instagramfilters.jade
+++ b/client/templates/instagramfilters.jade
@@ -15,7 +15,7 @@
     label(for="ga-caption") Caption Search
     input#ga-caption.form-control.input-sm(
       type="text", placeholder="Caption substring search",
-      title="Use quotes to specified exact required phrases, hashtags for exact hastag matches, () to group clauses, | for or, and ! or - to exclude phrases.",
+      title="Use quotes to specified exact required phrases, hashtags for exact hashtag matches, () to group clauses, | for or, and ! or - to exclude phrases.  For example, searching for 'hospital -\"hospitality\" finds hospitals but not warm welcomes.",
       taxifield="caption_search", taxitype="text")
   .form-group
     button#ga-instagram-filter.btn.btn-default.btn-sm

--- a/client/templates/results.jade
+++ b/client/templates/results.jade
@@ -10,7 +10,7 @@
               title="These are the instagram results based on the Caption Search in the Filters panel.")
       #ga-instagram-results.panel-collapse.collapse.in
         .panel-body
-          .results-table
+          .results-table.al-scroller
             table#ga-instagram-results-table
               tr
                 th Post Date

--- a/client/templates/results.jade
+++ b/client/templates/results.jade
@@ -15,3 +15,13 @@
               tr
                 th Post Date
                 th Caption
+#ga-instagram-overlay
+  .ga-instagram-overlay-image
+    img
+  .ga-instagram-overlay-text
+    .ga-instagram-overlay-arrow
+      i.icon-right-circled
+    span.ga-instagram-overlay-date
+    span.ga-instagram-overlay-caption
+  .ga-instagram-overlay-link
+    a


### PR DESCRIPTION
Show instagram photos and captions when you hover over them on the map or table.  We probably should make it so you can either move to a selected table entry or make the overlay sticky.

If the instagram point is not on the visible viewport, the overlay contains an arrow that points in the direction you need to move to see the point.

Perhaps the overlay should avoid the results table if it was created from the
results table.

Also, switched to building from the non-minified version of geojs.  We minify it when building, so the net result is the same, except that this allows chrome to show the unminified source.

Adjusted text queries to allow negation of quoted strings to not affect initial lexeme queries.

Typing enter on a text field will automatically update that control area.

Updated the geojs reference to match the new master.
