### PR TITLE
Instagram overlays can persist.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,7 +193,6 @@ module.exports = function (grunt) {
                 files: {
                     'built/libs.min.js': [
                         /* These items are from geojs, but we exclude jquery */
-                        'geojs/bower_components/jquery-mousewheel/jquery.mousewheel.js',
                         'geojs/bower_components/gl-matrix/dist/gl-matrix.js',
                         'geojs/bower_components/proj4/dist/proj4-src.js',
                         'geojs/bower_components/d3/d3.js',

--- a/client/js/activityLog.js
+++ b/client/js/activityLog.js
@@ -50,6 +50,8 @@
             desc: 'show instagram overlay'},
         inst_overlay_hide: {elem: 'map',    act: 'hide',
             desc: 'hide instagram overlay'},
+        inst_overlay_stick: {elem: 'map',   act: 'alter',
+            desc: 'persist instagram overlay'},
         inst_table:      {elem: 'listbox',  act: 'show',
             desc: 'show instagram table'},
         inst_table_add:  {elem: 'listbox',  act: 'alter',
@@ -194,9 +196,13 @@
                     value: $(this).attr('href')
                 });
             });
-            $('button', selector).on('click', function (evt) {
+            $('button,.log-as-button', selector).on('click', function (evt) {
+                var ctl = $(this);
                 log.logActivity('button_click', 'controls', {
-                    id: $(this).attr('id')
+                    id: ctl.attr('id'),
+                    closestId: (ctl.attr('id') ? undefined :
+                                ctl.closest('[id]').attr('id')),
+                    classes: ctl.attr('class')
                 });
             });
             $('input[type="checkbox"]:visible', selector)

--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -280,7 +280,6 @@ geoapp.views.ControlsView = geoapp.View.extend({
                 geoapp.map.ensureLayer('taxi');
                 geoapp.map.ensureLayer('instagram');
                 _.each(geoapp.placeOrder, function (placeKey) {
-                    console.log(geoapp.placeList[placeKey]);
                     var button = $('#ga-place-template').clone();
                     button.removeClass('hidden').attr({
                         'data-place': placeKey,

--- a/client/js/datahandler.js
+++ b/client/js/datahandler.js
@@ -23,7 +23,7 @@ geoapp.DataHandler = function (arg) {
     }
     arg = arg || {};
 
-    var m_verbose = 1;
+    var m_verbose = 0;
 
     /* maximumDataPoints defaults to the maximum of maximumMapPoints and
      * maximumVectors from the geoapp.map object. */
@@ -405,11 +405,13 @@ geoapp.dataHandlers.instagram = function (arg) {
         /* If hovering over a row, show the relevant instagram point */
         $('tr', table).off('.instagram-table'
         ).on('mouseleave.instagram-table', function (evt) {
-            layer.setCurrentPoint(null);
-        }).on('mouseenter.instagram-table', this.instagramTableHighlight
+            if (!layer.persistentCurrentPoint()) {
+                layer.currentPoint(null);
+            }
+        }).on('click.instagram-table mouseenter.instagram-table',
+            this.instagramTableHighlight
         );
-        //TODO:: zoom to that point if clicked, sort data table by date,
-        // inverse date, or original
+        //TODO:: sort data table by date, inverse date, or original
         return moreData;
     };
 
@@ -419,12 +421,19 @@ geoapp.dataHandlers.instagram = function (arg) {
      */
     this.instagramTableHighlight = function (evt) {
         var layer = geoapp.map.getLayer(m_this.datakey),
-            idx = $(evt.currentTarget).attr('item');
-        if (idx === '') {
-            layer.setCurrentPoint(null);
-            return;
+            idx = $(evt.currentTarget).attr('item'),
+            isClick = evt.type === 'click';
+        if (idx === '' || idx === undefined) {
+            idx = null;
         }
-        layer.setCurrentPoint(parseInt(idx), undefined, undefined, 'table');
+        if (isClick) {
+            layer.persistentCurrentPoint(idx, 'table');
+        } else {
+            if (layer.persistentCurrentPoint()) {
+                return;
+            }
+        }
+        layer.currentPoint(idx, isClick, isClick, 'table');
     };
 };
 

--- a/client/js/layers.js
+++ b/client/js/layers.js
@@ -853,12 +853,16 @@ geoapp.mapLayers.instagram = function (map, arg) {
         m_geoPoints,
         m_overlayTimer,
         m_mapEventsSet,
+        m_currentPoint = null,
+        m_currentPointSource = '',
+        m_persistentCurrentPoint = false,
+        m_inPoints = {top: [], other: []},
+        m_lastMouseDownEvent,
+        m_lastPanEvent,
 
         m_defaultOpacity = 0.1,
         m_pointColor = geo.util.convertColor('#FF0000'),
         m_strokeColor = geo.util.convertColor('#E69F00');
-
-    this.currentPoint = null;
 
     var geoLayer;
 
@@ -925,7 +929,12 @@ geoapp.mapLayers.instagram = function (map, arg) {
         .geoOn(geo.event.feature.mouseout, function (evt) {
             m_this.highlightPoint(evt.index, evt, false);
         });
-        this.setCurrentPoint(null, false);
+        m_geoPoints.layer().geoOff(geo.event.pan)
+        .geoOn(geo.event.pan, m_this.panLayer);
+        $(this.map.getMap().node()).off('.instagram-map-layer').on(
+            'mousedown.instagram-map-layer click.instagram-map-layer',
+            m_this.clickLayer);
+        this.currentPoint(null, false);
     };
 
     /* Return the index of the date column for this data.
@@ -1025,7 +1034,12 @@ geoapp.mapLayers.instagram = function (map, arg) {
         var state = {
             geoPoints: m_geoPoints,
             defaultOpacity: m_defaultOpacity,
-            pointColor: m_pointColor
+            currentPoint: m_currentPoint,
+            currentPointSource: m_currentPointSource,
+            persistentCurrentPoint: m_persistentCurrentPoint,
+            inPoints: m_inPoints,
+            pointColor: m_pointColor,
+            strokeColor: m_strokeColor
         };
         if (key) {
             return state[key];
@@ -1050,45 +1064,98 @@ geoapp.mapLayers.instagram = function (map, arg) {
                 over = false;
             }
         }
-        if (!this.inPoints) {
-            this.inPoints = {top: [], other: []};
+        if ((!over || !evt.top) && $.inArray(idx, m_inPoints.top) >= 0) {
+            m_inPoints.top.splice($.inArray(idx, m_inPoints.top), 1);
         }
-        if ((!over || !evt.top) && $.inArray(idx, this.inPoints.top) >= 0) {
-            this.inPoints.top.splice($.inArray(idx, this.inPoints.top), 1);
+        if ((!over || evt.top) && $.inArray(idx, m_inPoints.other) >= 0) {
+            m_inPoints.other.splice($.inArray(idx, m_inPoints.other), 1);
         }
-        if ((!over || evt.top) && $.inArray(idx, this.inPoints.other) >= 0) {
-            this.inPoints.other.splice($.inArray(idx, this.inPoints.other), 1);
+        if (over && evt.top && $.inArray(idx, m_inPoints.top) < 0) {
+            m_inPoints.top.push(idx);
         }
-        if (over && evt.top && $.inArray(idx, this.inPoints.top) < 0) {
-            this.inPoints.top.push(idx);
+        if (over && !evt.top && $.inArray(idx, m_inPoints.other) < 0) {
+            m_inPoints.other.push(idx);
         }
-        if (over && !evt.top && $.inArray(idx, this.inPoints.other) < 0) {
-            this.inPoints.other.push(idx);
+        if (!m_persistentCurrentPoint) {
+            this.currentPoint(this.getHighlightPoint(), undefined, undefined,
+                              'map');
         }
-        if (this.inPoints.top.length) {
-            cur = this.inPoints.top[0];
-        } else if (this.inPoints.other.length) {
-            cur = this.inPoints.other[0];
-        }
-        this.setCurrentPoint(cur, undefined, undefined, 'map');
     };
 
-    /* Set a point as the current point.  Mark it as the current point and set
-     * a timer to display the instagram picture soon.
+    /* Return the first top-most point that should be highlighted by a hovered
+     * or clicked mouse.
      *
-     * @param cur: the 0-based point index, or null to clear the current point.
+     * @return: the 0-based point index or null.
+     */
+    this.getHighlightPoint = function () {
+        if (m_inPoints.top.length) {
+            return m_inPoints.top[0];
+        }
+        if (m_inPoints.other.length) {
+            return m_inPoints.other[0];
+        }
+        return null;
+    };
+
+    /* Handle clicking on the map.  Set the current point according to
+     * highlighting rules to a persistent point.
+     *
+     * @param evt: the event that triggered this call.
+     */
+    this.clickLayer = function (evt) {
+        if (evt.type === 'mousedown') {
+            m_lastMouseDownEvent = new Date().getTime();
+            return;
+        }
+        if (m_lastMouseDownEvent < m_lastPanEvent) {
+            return;
+        }
+        var idx = m_this.getHighlightPoint();
+        m_this.persistentCurrentPoint(idx);
+        m_this.currentPoint(idx, true, true, 'map');
+        evt.stopPropagation();
+        evt.preventDefault();
+    };
+
+    /* When the map is panned, record that it was done so that we can
+     * differentiate a click from a pan.  If we have a persistent overlay,
+     * adjust its position.
+     *
+     * @param evt: the event that triggered this call.
+     */
+    this.panLayer = function (evt) {
+        m_lastPanEvent = new Date().getTime();
+        if (m_persistentCurrentPoint && m_currentPoint !== null) {
+            m_this.showOverlay(true);
+        }
+    };
+
+    /* Get or set a point as the current point.  If setting, mark it as the
+     * current point and set a timer to display the instagram picture soon.
+     *
+     * @param cur: undefined to get the current point.  Otherwise, the 0-based
+     *             point index, or null to clear the current point.
      * @param redraw: if false, don't redraw the map.  If true, always update.
      * @param immediate: if true, show or hide the overlay immediately.
      * @param source: name of the source of setting this point.  Used in
      *                logging.
+     * @param currentPoint: the current point (an integer) or null if there is
+     *                      no current point.
      */
-    this.setCurrentPoint = function (cur, redraw, immediate, source) {
-        this.currentPointSource = source || this.currentPointSource || '';
-        if (cur === this.currentPoint && redraw !== true) {
-            return;
+    this.currentPoint = function (cur, redraw, immediate, source) {
+        if (cur === undefined) {
+            return m_currentPoint;
+        }
+        m_currentPointSource = source || m_currentPointSource || '';
+        cur = !isNaN(parseInt(cur)) ? parseInt(cur) : null;
+        if (cur === m_currentPoint && redraw !== true) {
+            return m_currentPoint;
+        }
+        if (cur === null) {
+            m_persistentCurrentPoint = false;
         }
         var vpf = m_geoPoints.verticesPerFeature(),
-            stroke, i, old = this.currentPoint;
+            stroke, i, old = m_currentPoint;
 
         stroke = m_geoPoints.actors()[0].mapper().getSourceBuffer('stroke');
         for (i = 0; i < vpf; i += 1) {
@@ -1103,7 +1170,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
         if (redraw !== false) {
             this.map.triggerDraw();
         }
-        this.currentPoint = cur;
+        m_currentPoint = cur;
         /* If no point is selected, use a shorter timeout for the overlay. */
         var delay = !cur ? 125 : 250;
         if (m_overlayTimer) {
@@ -1117,31 +1184,67 @@ geoapp.mapLayers.instagram = function (map, arg) {
         }
         if (cur && !m_mapEventsSet && $('#ga-main-map').length) {
             $('#ga-main-map').on('mouseleave', function () {
-                m_this.setCurrentPoint(null);
+                if (!m_persistentCurrentPoint) {
+                    m_this.currentPoint(null);
+                }
             });
             m_mapEventsSet = true;
         }
+        return m_currentPoint;
+    };
+
+    /* Get or set if the current point is persistent. If it is persistent, a
+     * close icon is shown on the overlay.
+     *
+     * @param persistent: if undefined, just return the state of persistence.
+     *                    If an integer or a string that can be cast to an
+     *                    integer, set the persistence if this value is not the
+     *                    same as the current point or persistence if off.  If
+     *                    persistence in on and this is the currenr point,
+     *                    toggle it off.  If not an integer, set the
+     *                    persistence to the truthiness of this value.
+     * @param source: source of this call for logging.
+     * @return: a boolean with the state of persistence.
+     */
+    this.persistentCurrentPoint = function (persistent, source) {
+        if (persistent === undefined) {
+            return m_persistentCurrentPoint;
+        }
+        if (!isNaN(parseInt(persistent))) {
+            persistent = parseInt(persistent);
+            persistent = (!m_persistentCurrentPoint ||
+                          persistent !== m_currentPoint);
+        }
+        persistent = !!persistent;
+        if (persistent !== m_persistentCurrentPoint) {
+            geoapp.activityLog.logActivity('inst_overlay_stick',
+                source || 'map', {});
+        }
+        m_persistentCurrentPoint = persistent;
+        return m_persistentCurrentPoint;
     };
 
     /* Show or hide the overlay based on the current point.  If the current
      * point is off the screen, show the overlay as close to that point as we
      * can.
+     *
+     * @param onlyMove: if true, only update the position.
      */
-    this.showOverlay = function () {
+    this.showOverlay = function (onlyMove) {
         m_overlayTimer = null;
         var mapData = m_this.data(),
             overlay = $('#ga-instagram-overlay');
-        if (m_this.currentPoint === null || !mapData.data ||
-                m_this.currentPoint >= mapData.data.length) {
-            overlay.css('display', 'none');
+        if (m_currentPoint === null || !mapData.data ||
+                m_currentPoint >= mapData.data.length) {
             if (overlay.css('display') !== 'none') {
                 geoapp.activityLog.logActivity('inst_overlay_hide', 'map', {
                     url: null
                 });
             }
+            overlay.css('display', 'none');
             return;
         }
-        var item = mapData.data[m_this.currentPoint];
+        var item = mapData.data[m_currentPoint];
         var mapW = $('#ga-main-map').width(),
             mapH = $('#ga-main-map').height(),
             pos = m_this.map.getMap().gcsToDisplay({
@@ -1154,11 +1257,6 @@ geoapp.mapLayers.instagram = function (map, arg) {
             caption = item[mapData.columns.caption] || '',
             date = moment(item[mapData.columns.posted_date]).utcOffset(0
                 ).format('MM-DD HH:mm');
-        $('.ga-instagram-overlay-date', overlay).text(date).attr('title', date);
-        $('.ga-instagram-overlay-caption', overlay).text(caption).attr(
-            'title', caption);
-        $('.ga-instagram-overlay-link a', overlay).text(url).attr(
-            'href', url);
         if (pos.x >= 0 && pos.y >= 0 && pos.x <= mapW && pos.y <= mapH) {
             $('.ga-instagram-overlay-arrow', overlay).css('display', 'none');
         } else {
@@ -1177,22 +1275,57 @@ geoapp.mapLayers.instagram = function (map, arg) {
             });
             offset = 0;
         }
+        /* Bias very slightly to the upper right */
+        var bias = 5,
+            ctrX = mapW / 2 + bias,
+            ctrY = mapH / 2 - bias;
         overlay.css({
-            left: pos.x <= mapW / 2 ? (pos.x + offset) + 'px' : '',
-            right: pos.x <= mapW / 2 ? '' : (mapW - pos.x + offset) + 'px',
-            top: pos.y <= mapH / 2 ? (pos.y + offset) + 'px' : '',
-            bottom: pos.y <= mapH / 2 ? '' : (mapH - pos.y + offset) + 'px'
-        }).off('.instagram-overlay'
-        ).on('mouseenter.instagram-overlay', function () {
-            if (m_overlayTimer) {
-                window.clearTimeout(m_overlayTimer);
-                m_overlayTimer = null;
-            }
-        }).on('mouseleave.instagram-overlay', function () {
-            m_overlayTimer = window.setTimeout(function () {
-                m_this.setCurrentPoint(null, true, true);
-            }, 500);
+            left:   pos.x < ctrX ? (pos.x + offset) + 'px' : '',
+            right:  pos.x < ctrX ? '' : (mapW - pos.x + offset) + 'px',
+            top:    pos.y < ctrY ? (pos.y + offset) + 'px' : '',
+            bottom: pos.y < ctrY ? '' : (mapH - pos.y + offset) + 'px'
         });
+        if (onlyMove) {
+            return;
+        }
+        $('.ga-instagram-overlay-date', overlay).text(date).attr(
+            'title', date);
+        $('.ga-instagram-overlay-caption', overlay).text(caption).attr(
+            'title', caption);
+        $('.ga-instagram-overlay-link a', overlay).text(url).attr(
+            'href', url);
+        $('.ga-instagram-overlay-title-bar', overlay).css('display',
+            m_persistentCurrentPoint ? 'block' : 'none');
+        overlay.off('.instagram-overlay');
+        $('*', overlay).off('.instagram-overlay');
+        if (!m_persistentCurrentPoint) {
+            overlay.on('mouseenter.instagram-overlay', function () {
+                if (m_overlayTimer) {
+                    window.clearTimeout(m_overlayTimer);
+                    m_overlayTimer = null;
+                }
+            }).on('mouseleave.instagram-overlay', function () {
+                m_overlayTimer = window.setTimeout(function () {
+                    m_this.currentPoint(null, true, true);
+                }, 500);
+            });
+        } else {
+            $('.ga-instagram-overlay-goto', overlay).on(
+                    'click.instagram-overlay', function () {
+                m_this.map.getMap().transition({
+                    center: {
+                        x: item[mapData.columns.longitude],
+                        y: item[mapData.columns.latitude]
+                    },
+                    interp: d3.interpolateZoom,
+                    duration: 1000
+                });
+            });
+            $('.ga-instagram-overlay-close-button', overlay).on(
+                    'click.instagram-overlay', function () {
+                m_this.currentPoint(null, true, true);
+            });
+        }
         imageUrl = url.replace(/\/$/, '') + '/media?size=m';
         if ($('img', overlay).attr('orig_url') !== url) {
             overlay.css('display', 'none');
@@ -1202,14 +1335,14 @@ geoapp.mapLayers.instagram = function (map, arg) {
                 $('.ga-instagram-overlay-image', overlay).css('display', '');
                 overlay.css('display', 'block');
                 geoapp.activityLog.logActivity('inst_overlay', 'map', {
-                    source: m_this.currentPointSource || '',
+                    source: m_currentPointSource || '',
                     imageUrl: imageUrl,
                     url: url
                 });
             }).on('error.instagram-overlay', function () {
                 overlay.css('display', 'block');
                 geoapp.activityLog.logActivity('inst_overlay', 'map', {
-                    source: m_this.currentPointSource || '',
+                    source: m_currentPointSource || '',
                     url: url
                 });
             }).attr({src: imageUrl, orig_url: url});

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -63,7 +63,7 @@ geoapp.Map = function (arg) {
         m_animationData,
         m_animTimer,
 
-        m_verbose = 1;
+        m_verbose = 0;
 
     /* Show a map with data.  If we have already shown the map, just update
      * the data and redraw the map.  The data is an object that contains:

--- a/client/js/speedtest.js
+++ b/client/js/speedtest.js
@@ -18,7 +18,12 @@ geoapp.views.SpeedTestView = geoapp.View.extend({
 
     displayParams: {
         'display-tile-set': 'mapquest',
-        'display-tile-opacity': 1
+        'display-tile-opacity': 1,
+        'data-opacity': 0.1,
+        'display-max-points': 10000000000,
+        'display-max-lines': 10000000000,
+        'show-taxi-data': true,
+        'show-instagram-data': false
     },
     sizeFactors: [1, 1.5, 2, 3, 5, 7.5],
     tests: [

--- a/client/stylesheets/main.styl
+++ b/client/stylesheets/main.styl
@@ -241,5 +241,20 @@ a
     float right
     font-size 24px
     transform rotate(0deg)
-
-
+  .ga-instagram-overlay-title-bar
+    font-size 20px
+    line-height 1em
+    height 15px
+    display none
+    .ga-instagram-overlay-close-button
+      position absolute
+      top -5px
+      right -5px
+      width 1.2em
+      :hover
+        text-shadow 1px 1px 1px white,-1px 1px 1px white,-1px -1px 1px white,1px -1px 1px white
+    .ga-instagram-overlay-goto
+      padding 0 4px 0 0
+      line-height 1em
+      font-weight bold
+      margin -12px 0 0 0

--- a/client/templates/results.jade
+++ b/client/templates/results.jade
@@ -16,6 +16,12 @@
                 th Post Date
                 th Caption
 #ga-instagram-overlay
+  .ga-instagram-overlay-title-bar
+    button.ga-instagram-overlay-goto.btn.btn-sm
+      i.icon-target
+      |  Center
+    .ga-instagram-overlay-close-button.log-as-button
+      i.icon-cancel
   .ga-instagram-overlay-image
     img
   .ga-instagram-overlay-text


### PR DESCRIPTION
Instagram overlays can be sticky by clicking on the list or map.  Clicking a blank area on the map or the same point or list item will un-stick the overlay.  The overlay moves when the map is panned.

Fixed a minor bug where hovering over the instagram list table header would log an error to the console.

Update the speed test to handle other changes.

Updated to the latest geojs which removes the need for mousewheel.

Decreased the default verbosity.

Update Draper logging for the new elements.
