### PR TITLE
Fix a few graph issues.

### DIFF
--- a/client/js/layersInstagram.js
+++ b/client/js/layersInstagram.js
@@ -535,14 +535,12 @@ geoapp.mapLayers.instagram = function (map, arg) {
         $('.ga-instagram-overlay-link a', overlay).text(url).attr(
             'href', url);
         if ($('img', overlay).attr('orig_url') !== url) {
-            overlay.css('display', 'none');
-            $('.ga-instagram-overlay-image', overlay).css('display', 'none');
+            overlay.css('display', 'none').addClass('no-overlay-image');
             $('img', overlay).off('.instagram-overlay').attr({orig_url: url});
             if (imageUrl) {
                 $('img', overlay).on('load.instagram-overlay', function () {
-                    $('.ga-instagram-overlay-image', overlay).css(
-                        'display', '');
                     overlay.css('display', 'block');
+                    overlay.removeClass('no-overlay-image');
                     geoapp.activityLog.logActivity('show_overlay', 'map', {
                         source: m_currentPointSource || '',
                         imageUrl: imageUrl,

--- a/client/stylesheets/controls.styl
+++ b/client/stylesheets/controls.styl
@@ -233,12 +233,17 @@
       width 100%
   .ga-instagram-overlay-text
     width 100%
-    max-height 56px
+    max-height 72px
     line-height 16px
     overflow-x hidden
-    overflow-y scroll
+    overflow-y auto
     word-wrap break-word
     white-space normal
+  &.no-overlay-image
+    .ga-instagram-overlay-image
+      display none
+    .ga-instagram-overlay-text
+      max-height 120px
   .ga-instagram-overlay-date
     padding-right 5px
     font-weight bold

--- a/client/stylesheets/graph.styl
+++ b/client/stylesheets/graph.styl
@@ -1,5 +1,8 @@
 @import 'nib'
 
+#ga-graph-panel .panel
+  overflow visible
+
 #ga-graph-page
   left inherit
   bottom inherit

--- a/client/templates/graphSettingsWidget.jade
+++ b/client/templates/graphSettingsWidget.jade
@@ -52,7 +52,7 @@
             input(type="checkbox", checked=($.inArray(datakey, series) >= 0 ?
                 "checked" : undefined))
             .ga-dataset-name
-              = datasetInfo[datakey].name
+              = datasetInfo[datakey].longname ? datasetInfo[datakey].longname : datasetInfo[datakey].name
       .g-validation-failed-message
     .modal-footer
       a.btn.btn-small.btn-default(data-dismiss="modal") Cancel


### PR DESCRIPTION
Show day of week in the graph tooltip.

Don't hide overflow from the graph panel, as it covers long tooltips.

Add units to graph axes.

Improve graph data set names shown in the dialog.

The log based taxi graphs are now all based on trips/hour.  This allows direct comparison of monthly and daily graphs.

Convert log scales to human values for axes and tooltips.

Adjust instagram overlay size.  Add one line of text in general.  Hide the scrollbar unless needed.  If there is no image, allow even more text.
