### PR TITLE
Auto-update bins on map movement.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -381,9 +381,10 @@ geoapp.views.ControlsView = geoapp.View.extend({
             }
         });
         ctls.trigger($.Event('ready.geoapp.view', {relatedTarget: ctls}));
-        $('#ga-main-map').off('ga:map.moved').on('ga:map.moved', function () {
-            view.mapMoved();
-        });
+        $('#ga-main-map').off('ga:map.moved.quick').on(
+            'ga:map.moved.quick', function () {
+                view.mapMoved();
+            });
         geoapp.View.prototype.render.apply(this, arguments);
         return this;
     },
@@ -827,6 +828,11 @@ geoapp.views.ControlsView = geoapp.View.extend({
         var display  = this.updateSection('display', false);
         if (display['display-process'] === 'binned') {
             $('#ga-display-update').addClass('btn-primary');
+            geoapp.throttleCallback('updatebin', _.bind(function () {
+                $('#ga-display-update').removeClass('btn-primary');
+                geoapp.map.updateMapParams(
+                    'all', this.updateSection('display', false), 'always');
+            }, this), 0, 300);
         }
     },
 

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -132,10 +132,15 @@ geoapp.Map = function (arg) {
                 return;
             }
         }
+        var bounds = m_geoMap.bounds();
+        var zoom = m_geoMap.zoom();
+        /* The quick version of the event fires on all movements. */
+        $('#ga-main-map').trigger('ga:map.moved.quick', {
+            bounds: bounds,
+            zoom: zoom
+        });
         if (!m_panTimer) {
             var view = this;
-            var bounds = m_geoMap.bounds();
-            var zoom = m_geoMap.zoom();
             geoapp.activityLog.logActivity('map_moved', 'map', {
                 bounds: bounds,
                 zoom: zoom
@@ -147,6 +152,7 @@ geoapp.Map = function (arg) {
                 y1: bounds.lowerRight.y.toFixed(7),
                 zoom: zoom.toFixed(2)
             }, false, true);
+            /* The non-quick version of the event is throttled */
             $('#ga-main-map').trigger('ga:map.moved', {
                 bounds: bounds,
                 zoom: zoom
@@ -155,7 +161,6 @@ geoapp.Map = function (arg) {
             m_panTimer = window.setTimeout(function () {
                 view.mapMovedEvent();
             }, 250);
-            return;
         } else {
             m_panQueued = true;
         }

--- a/client/stylesheets/controls.styl
+++ b/client/stylesheets/controls.styl
@@ -105,6 +105,8 @@
     width 290px
   #ga-tile-opacity-ctl,#ga-data-opacity-ctl
     width 25px
+  #ga-display-num-bins-ctl
+    width 52px
   .ga-slider-label
     padding-right 1px
   #ga-data-trips-ctl,#ga-display-max-points-ctl,#ga-display-max-lines-ctl,#ga-inst-data-grams-ctl

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -86,11 +86,13 @@ mixin standardPanel(panel_id, content_id, title, tooltip)
             taxifield="display-max-lines", taxitype="int")
       span#ga-display-num-bins-group.hidden
         label(for="ga-display-num-bins") Bins
-        input#ga-display-num-bins.form-control.input-sm(
-          type="text", placeholder="#",
-          title="Number of bins across short dimension of the map",
-          taxifield="display-num-bins", taxitype="int")
-        button#ga-display-update.btn.btn-default.btn-sm
+        input#ga-display-num-bins.form-control.input-sm.ga-slider-ctl(
+            type="text", data-slider-min="5",
+            data-slider-max="30", data-slider-step="1",
+            data-slider-value="15", data-slider-handle="square",
+            data-slider-id="ga-display-num-bins-ctl",
+            taxifield="display-num-bins", taxitype="int")
+        button#ga-display-update.btn.btn-default.btn-sm.hidden
           i.icon-cw
           |  Update Bins
       label.ga-slider-label(for="ga-data-opacity",


### PR DESCRIPTION
This allows the removal of the update bins button.

Added a general function to throttle callbacks, as I expect we'll do it more in the future.

Addresses issue #147.
