### PR TITLE
One date control.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -167,6 +167,8 @@ geoapp.views.ControlsView = geoapp.View.extend({
             if (filter === 'taxi' && $('#ga-use-taxi-dates').is(':checked')) {
                 $('#ga-instagram-filter').addClass('btn-primary');
             }
+            $('#ga-taxi-filter').trigger('click');
+            $('#ga-instagram-filter').trigger('click');
         },
         'keydown input.ga-date-range': function (evt) {
             $(evt.target).data('daterangepicker').hide();
@@ -645,7 +647,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
             params = $.extend({}, results['taxi-filter'],
                               results['general-filter']);
             geoapp.dataLoaders.taxi.dataLoad({
-                params: results['taxi-filter'],
+                params: params,
                 display: results.display
             });
         }

--- a/client/stylesheets/controls.styl
+++ b/client/stylesheets/controls.styl
@@ -134,6 +134,12 @@
     padding-left 3px
   #ga-display-update
     margin 0 0 0 10px
+  .ga-section-label
+    margin-left 20px
+    color #433E90
+  .ga-section-group
+    border-top 1px solid #DDD
+    margin-top 3px
 
 .ga-results-ui
   right 0

--- a/client/templates/instagramfilters.jade
+++ b/client/templates/instagramfilters.jade
@@ -1,15 +1,17 @@
 #ga-instagram-filter-settings(ga-filter-name="instagram")
+  .form-group.ga-section-group
+    label.ga-section-label Twitter and Instagram Messages
   .form-group.hidden
     label(for="ga-msgsource") Data Source
     select#ga-msgsource.form-control.input-sm(title="Database message source",
         taxifield="msgsource")
-  .form-group
+  .form-group.hidden
     span(title="Use pickup dates if checked")
       input#ga-use-taxi-dates.form-control.input-sm(
-        type="checkbox",
+        type="checkbox", checked="checked",
         taxifield="use_taxi_dates", taxitype="boolean")
-      label(for="ga-use-taxi-dates") Use Pickup Date Range
-  .form-group
+      label(for="ga-use-taxi-dates") Use Trip Date Range
+  .form-group.hidden
     label(for="ga-posted-date") Posted Date
     input#ga-posted-date.ga-date-range.form-control.input-sm(
       type="text", placeholder="MMM DD hh:mm - MMM DD hh:mm",
@@ -22,7 +24,8 @@
       title="Use quotes to specify exact required phrases, hashtags for exact hashtag matches, () to group clauses, | for or, and ! or - to exclude phrases.  For example, searching for 'hospital -\"hospitality\" finds hospitals but not warm welcomes.",
       taxifield="caption_search", taxitype="text")
   .form-group
-    button#ga-instagram-filter.btn.btn-default.btn-sm
+    button#ga-instagram-filter.btn.btn-default.btn-sm(
+        title="Load message information from the database")
       i.icon-ok
       |  Filter
     #ga-instagram-loading.ga-loading-spinner.hidden

--- a/client/templates/taxifilters.jade
+++ b/client/templates/taxifilters.jade
@@ -1,4 +1,12 @@
 #ga-taxi-filter-settings(ga-filter-name="taxi")
+  .form-group
+    label(for="ga-pickup-date") Date
+    input#ga-pickup-date.ga-date-range.form-control.input-sm(
+      type="text", placeholder="MMM DD hh:mm - MMM DD hh:mm",
+      title="Pickup date range",
+      taxifield="pickup_datetime", taxitype="dateRange")
+  .form-group.ga-section-group
+    label.ga-section-label Taxi and Bike Share
   .form-group.hidden
     label(for="ga-source") Data Source
     select#ga-source.form-control.input-sm(title="Database Taxi source",
@@ -8,19 +16,13 @@
     .form-group
       label(for="ga-medallion") Medallion
       input#ga-medallion.form-control.input-sm(
-        type="text", placeholder="#XX##", title="Taxi medallion",
+        type="text", placeholder="#XX##", title="Taxi medallion or bike ID",
         taxifield="medallion")
     .form-group
       label(for="ga-hack-license") Hack License
       input#ga-hack-license.form-control.input-sm(
         type="text", placeholder="#######", title="Hack license",
         taxifield="hack_license")
-  .form-group
-    label(for="ga-pickup-date") Pickup Date
-    input#ga-pickup-date.ga-date-range.form-control.input-sm(
-      type="text", placeholder="MMM DD hh:mm - MMM DD hh:mm",
-      title="Pickup date range",
-      taxifield="pickup_datetime", taxitype="dateRange")
   .form-group
     label(for="ga-trip-distance") Trip Distance
     input#ga-trip-distance.form-control.input-sm(
@@ -34,7 +36,8 @@
       title="Number of passengers",
       taxifield="passenger_count", taxitype="intRange")
   .form-group
-    button#ga-taxi-filter.btn.btn-default.btn-sm
+    button#ga-taxi-filter.btn.btn-default.btn-sm(
+        title="Load trip information from the database")
       i.icon-ok
       |  Filter
     #ga-taxi-loading.ga-loading-spinner.hidden


### PR DESCRIPTION
For now, make it appear that there is only one date control for both trips and messages.  Selecting apply from the daterangepicker automatically filters the data.

Resolves issue #165.
