### PR TITLE
Better database connections.

### DIFF
--- a/client/js/datahandler.js
+++ b/client/js/datahandler.js
@@ -334,6 +334,7 @@ geoapp.dataHandlers.taxi = function (arg) {
         geoapp.cancelRestRequests('taxidata');
         this.loadingAnimation('#ga-taxi-loading', false,
                               !options.params.offset);
+        options.params.clientid = geoapp.clientID;
         var xhr = geoapp.restRequest({
             path: 'geoapp/taxi', type: 'GET', data: options.params
         }).done(_.bind(function (resp) {
@@ -454,6 +455,7 @@ geoapp.dataHandlers.instagram = function (arg) {
             this.loadingAnimation('#ga-instagram-loading', false,
                                   !options.params.offset);
         }
+        options.params.clientid = geoapp.clientID;
         var xhr = geoapp.restRequest({
             path: 'geoapp/' + options.access, type: 'GET', data: options.params
         }).done(_.bind(function (resp) {

--- a/client/js/general.js
+++ b/client/js/general.js
@@ -160,3 +160,18 @@ geoapp.throttleCallback = function (name, callback, minDelay, initDelay) {
         delete geoapp.ThrottledCallbacks[name];
     }
 };
+
+/* Get a valid random GUID.  See http://stackoverflow.com/questions/105034
+ *
+ * @returns: a random UUID that conforms to the official spec.
+ */
+geoapp.getRandomUUID = function () {
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(
+        /[xy]/g, function (c) {
+            /* jshint bitwise: false */
+            var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+            /* jshint bitwise: true */
+            return v.toString(16);
+        });
+    return uuid;
+};

--- a/client/js/layersInstagram.js
+++ b/client/js/layersInstagram.js
@@ -116,7 +116,7 @@ geoapp.mapLayers.instagram = function (map, arg) {
         .geoOn(geo.event.feature.mouseout, function (evt) {
             m_this.highlightPoint(evt.index, evt, false);
         });
-        m_geoPoints.layer().geoOff(geo.event.pan)
+        m_geoPoints.layer().geoOff(geo.event.pan, m_this.panLayer)
         .geoOn(geo.event.pan, m_this.panLayer);
         $(this.map.getMap().node()).off('.instagram-map-layer').on(
             'mousedown.instagram-map-layer click.instagram-map-layer',

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -25,7 +25,6 @@ geoapp.version = '0.1.4';
 geoapp.App = geoapp.View.extend({
     initialize: function () {
         geoapp.clientID = geoapp.getRandomUUID();
-        console.log('clientID', geoapp.clientID); //DWM::
         geoapp.restRequest({
             path: 'user/me'
         }).done(_.bind(function () {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -24,6 +24,8 @@ geoapp.version = '0.1.4';
 
 geoapp.App = geoapp.View.extend({
     initialize: function () {
+        geoapp.clientID = geoapp.getRandomUUID();
+        console.log('clientID', geoapp.clientID); //DWM::
         geoapp.restRequest({
             path: 'user/me'
         }).done(_.bind(function () {

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -42,6 +42,7 @@ mixin standardPanel(panel_id, content_id, title, tooltip, group)
         option(value="tonerlite") Stamen Toner Lite
         option(value="stamenterrain") Stamen Terrain
         option(value="blank") Blank
+        //- option(value="grid") Grid
       label.ga-slider-label(for="ga-tile-opacity",
           title="Map layer opacity") Opacity
       input#ga-tile-opacity.form-control.input-sm.ga-slider-ctl(


### PR DESCRIPTION
Introduced the concept of a client to a rest end point.  If the client requeries before a preceding query is finished, the preceding query is cancelled.

A connection pool has been added so that multiple clients can make simultaneous queries, and database connections are kept open for a while for quicker connection.  If no client has used a connection for a while, it is closed.  If more clients make simultaneous queries than the pool is large, extra connections are opened as needed (up to Postgres's limit).  If a query fails for a reason (such as a temporary network glitch), a new connection is attempted rather than using one in the pool.

Initial work to support newer version of geojs.  Updated to the latest version that isn't broken for this app.

Added a grid tile service to make testing geojs parallel projection easier.
