### PR TITLE
Add the ability to highlight recent messages.

### DIFF
--- a/client/js/datahandler.js
+++ b/client/js/datahandler.js
@@ -688,9 +688,14 @@ geoapp.dataHandlers.instagram = function (arg) {
                 dataIndices = m_sortedIndices.slice(current, current + page);
                 break;
             default:
-                for (i = current; i < data.data.length && i < current + page;
-                        i += 1) {
-                    dataIndices.push(i);
+                if (data.sortedIndices) {
+                    dataIndices = data.sortedIndices.slice(current,
+                                                           current + page);
+                } else {
+                    for (i = current; i < data.data.length && i < current + page;
+                            i += 1) {
+                        dataIndices.push(i);
+                    }
                 }
                 break;
         }

--- a/client/js/layers.js
+++ b/client/js/layers.js
@@ -48,6 +48,8 @@ geoapp.MapLayer = function (map, datakey, arg) {
      *      set or present, the date restriction is not used.
      *   dateMin: the minimum (inclusive) date for the data.
      *   dateMax: the maximum (exclusive) date for the data.
+     *   maxPoints: only maintain this many points, if set.
+     *   sortByDate: if truthy, sort the resulting points by date.
      *
      * @param data: if present, set the layer's data to this, otherwise return
      *              the current data.  If === true or === false, use this as
@@ -84,6 +86,30 @@ geoapp.MapLayer = function (map, datakey, arg) {
                 data.data = _.filter(data.data, function (d) {
                     return ((!vis.dateMin || d[col] >= vis.dateMin) &&
                         (!vis.dateMax || d[col] < vis.dateMax));
+                });
+            }
+            if (vis && vis.maxPoints) {
+                if (data === m_data) {
+                    data = _.clone(data);
+                }
+                data.data = data.data.slice(0, vis.maxPoints);
+            }
+            if (vis && vis.sortByDate && vis.dateColumn && data.columns &&
+                    data.columns[vis.dateColumn] !== undefined) {
+                if (data === m_data) {
+                    data = _.clone(data);
+                }
+                col = data.columns[vis.dateColumn];
+                _.each(data.data, function (d, idx) {
+                    d.origOrder = idx;
+                });
+                data.data = _.sortBy(data.data, function (d) {
+                    return d[col];
+                });
+                data.sortedIndices = [];
+                _.each(data.data, function (d, idx) {
+                    data.sortedIndices[d.origOrder] = idx;
+                    delete d.origOrder;
                 });
             }
             m_dataVisible = data;

--- a/client/js/layersInstagram.js
+++ b/client/js/layersInstagram.js
@@ -37,8 +37,10 @@ geoapp.mapLayers.instagram = function (map, arg) {
         m_lastPanEvent,
 
         m_defaultOpacity = 0.1,
-        m_pointColor = geo.util.convertColor('#FF0000'),
-        m_strokeColor = geo.util.convertColor('#E69F00'),
+        m_pointColorStr = '#FF0000',
+        m_pointColor = geo.util.convertColor(m_pointColorStr),
+        m_strokeColorStr = '#E69F00',
+        m_strokeColor = geo.util.convertColor(m_strokeColorStr),
 
         /* If both recentPointCount and recentPointTime are falsy, no recent
          * poinr highlighting is performed.  Otherwise, recentPointCount is
@@ -72,6 +74,12 @@ geoapp.mapLayers.instagram = function (map, arg) {
         m_oldPointColorStr = (recentMsg.oldPointColor !== undefined ?
             recentMsg.oldPointColor : m_oldPointColorStr);
         m_oldPointColor = geo.util.convertColor(m_oldPointColorStr);
+        m_pointColorStr = (recentMsg.pointColor !== undefined ?
+            recentMsg.pointColor : m_pointColorStr);
+        m_pointColor = geo.util.convertColor(m_pointColorStr);
+        m_strokeColorStr = (recentMsg.strokeColor !== undefined ?
+            recentMsg.strokeColor : m_strokeColorStr);
+        m_strokeColor = geo.util.convertColor(m_strokeColorStr);
     }
 
     geoLayer = map.getMap().createLayer('feature', {
@@ -117,12 +125,17 @@ geoapp.mapLayers.instagram = function (map, arg) {
         $('.ga-legend-item.legend-messages-old,' +
                 '.ga-legend-item.legend-messages-new').toggleClass(
             'hidden', !visible || !recent);
-        if (recent && visible) {
-            $('.ga-legend-item.legend-messages-old i').css(
-                'color', m_oldPointColorStr);
-        }
         if (!visible) {
             return;
+        }
+        if (recent) {
+            $('.ga-legend-item.legend-messages-old i').css(
+                'color', m_oldPointColorStr);
+            $('.ga-legend-item.legend-messages-new i').css(
+                'color', m_pointColorStr);
+        } else {
+            $('.ga-legend-item.legend-messages i').css(
+                'color', m_pointColorStr);
         }
         if (params['data-opacity'] > 0) {
             params['inst-opacity'] = params['data-opacity'];

--- a/client/js/map.js
+++ b/client/js/map.js
@@ -89,6 +89,8 @@ geoapp.Map = function (arg) {
             m_geoMap = geo.map({
                 node: '#ga-main-map',
                 center: m_defaultCenter,
+                parallelProjection: true,
+                discreteZoom: true,
                 zoom: m_defaultZoom
             });
             /* jscs:disable requireBlocksOnNewline */

--- a/client/stylesheets/controls.styl
+++ b/client/stylesheets/controls.styl
@@ -153,6 +153,8 @@
       resize vertical
       table
         font-size 12px
+        th
+          min-width 80px
         td
           user-select text
           overflow hidden
@@ -183,6 +185,11 @@
     text-shadow 0 0 1px black
   &.legend-messages i
     color #F00
+  &.legend-messages-new i
+    color #F00
+    opacity 0.95
+  &.legend-messages-old i
+    color #800
   &.taxi-binned i
     font-size 14px
     opacity 1

--- a/client/templates/controls.jade
+++ b/client/templates/controls.jade
@@ -170,6 +170,12 @@ mixin standardPanel(panel_id, content_id, title, tooltip, group)
       .ga-legend-item.legend-messages.hidden
         i.icon-circle
         | Messages
+      .ga-legend-item.legend-messages-new.hidden
+        i.icon-circle
+        | Recent Messages
+      .ga-legend-item.legend-messages-old.hidden
+        i.icon-circle
+        | Older Messages
     .form-group#ga-place-group
       //- The place buttons are taken from the ini settings or defaults
         based on this template

--- a/conf/geoapp.dist.cfg
+++ b/conf/geoapp.dist.cfg
@@ -24,7 +24,7 @@ defaultEndDate: "2015-07-01"
 # messages are a transition color between the recent and old colors.  If
 # recentPointTime is non-zero (and recentPointCount is unspecified or zero),
 # messages more recent than the specified number of seconds are highlighted.
-#recentMessages: {"oldPointColor": "#800000", "recentOpacityBoost": 4, "recentPointCount": 0, "lessRecentPointCount": 1000, "recentPointTime": 86400, "lessRecentPointTime": 86400}
+#recentMessages: {"pointColor": "#80FF00", "oldPointColor": "#800000", "recentOpacityBoost": 4, "recentPointCount": 0, "lessRecentPointCount": 1000, "recentPointTime": 86400, "lessRecentPointTime": 86400}
 
 # Each entry in this section is an available database.  The order is by lowest
 # "order" value, then alphabetically for ties.  Each entry consists of {"name":

--- a/conf/geoapp.dist.cfg
+++ b/conf/geoapp.dist.cfg
@@ -19,6 +19,13 @@ defaultYear: "2013"
 defaultStartDate: "2013-01-01"
 defaultEndDate: "2015-07-01"
 
+# You can have recent messages highlighted.  If recentPointCount is non-zero,
+# then that many recent messages are highlighted, and lessRecentPointCount
+# messages are a transition color between the recent and old colors.  If
+# recentPointTime is non-zero (and recentPointCount is unspecified or zero),
+# messages more recent than the specified number of seconds are highlighted.
+#recentMessages: {"oldPointColor": "#800000", "recentOpacityBoost": 4, "recentPointCount": 0, "lessRecentPointCount": 1000, "recentPointTime": 86400, "lessRecentPointTime": 86400}
+
 # Each entry in this section is an available database.  The order is by lowest
 # "order" value, then alphabetically for ties.  Each entry consists of {"name":
 # (name shown to the user), "class": (internal database class, such as

--- a/server/main.py
+++ b/server/main.py
@@ -64,8 +64,11 @@ class GeoAppRoot(object):
             if key in config:
                 iniList[sectionList[key]] = json.dumps(config[key])
         for key in iniList:
+            val = iniList[key]
+            if not isinstance(val, basestring):
+                val = json.dumps(val)
             vars['iniSettings'] += '%s=\'%s\' ' % (
-                key, xml.sax.saxutils.escape(iniList[key]))
+                key, xml.sax.saxutils.escape(val))
         data = {}
         for dbtype in ('taxidata', 'instagramdata'):
             datalist = []

--- a/utils/ingest_mongo_gnip_to_pg.py
+++ b/utils/ingest_mongo_gnip_to_pg.py
@@ -114,6 +114,7 @@ def convertGnipToTwitterItem(gnip):
         'msg_id': gnip['object']['id'].split(':')[-1],
         'user_id': gnip['actor']['id'].split(':')[-1],
         'user_name': gnip['actor']['preferredUsername'],
+        'user_fullname': gnip['actor'].get('displayName', None),
         'msg_date': int(date / 1000),
         'msg_date_ms': date,
         'msg': gnip['body'],


### PR DESCRIPTION
Ideally, for time-based highlighting, we would adjust the points at least every 1/255 of the smaller of the recent and less-recent time intervals so that points would fade out on their own, rather than relying on new data coming in and causing a redraw.

Fixed a style on the message table for short dates.

Also, prepare for when geojs has parallel projection and discrete zoom, and fix a minor issue with a realtime ingest script.
