### PR TITLE
Update to the latest geojs.

### DIFF
--- a/client/js/map.js
+++ b/client/js/map.js
@@ -31,7 +31,7 @@ geoapp.TileSets = {
         credit: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
     },
     stamenterrain: {
-        url: 'http://tile.stamen.com/terrain/',
+        url: 'http://tile.stamen.com/terrain',
         credit: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
     },
     blank: {url: 'api/v1/geoapp/tiles/blank/'}
@@ -60,7 +60,7 @@ geoapp.Map = function (arg) {
         m_defaultCenter = {x: -73.978165, y: 40.757977},
         m_defaultGoodZone = 5, /* in degrees of latitude and longitude */
         m_goodExtents,
-        m_defaultZoom = 10,
+        m_defaultZoom = 13,
 
         m_cycleDateRange,
         m_cycleDateRangeData = {},
@@ -90,7 +90,7 @@ geoapp.Map = function (arg) {
                 node: '#ga-main-map',
                 center: m_defaultCenter,
                 parallelProjection: true,
-                discreteZoom: true,
+                /* discreteZoom: true, */
                 zoom: m_defaultZoom
             });
             /* jscs:disable requireBlocksOnNewline */


### PR DESCRIPTION
This at least partially addresses issue #45.  I can clearly see the jitter with the older version of geojs when zoomed in such that we exceed the tile zoom level 18 (using a large window, this is functionally zoom level 20.5 or 21).  This jitter is gone even when I allow zoom levels of 21 with the new version of geojs.
