### PR TITLE
More tuning for elasticsearch.

### DIFF
--- a/client/stylesheets/controls.styl
+++ b/client/stylesheets/controls.styl
@@ -59,6 +59,8 @@
       display inherit
   .animate-spin
     animation spin 3s infinite linear
+  .poll-load,.delayed-load
+    animation finalpulse 10s infinite linear
   .ga-loading-spinner
     font-size 20px
     line-height 1em
@@ -66,9 +68,19 @@
     position relative
     top 5px
     left 4px
+    color rgba(0,0,0,0)
+  .ga-loading-spinner.first-load
     color black
   .ga-loading-spinner.second-load
     color #555555
+  .ga-loading-spinner.poll-load
+    color #C0C0C0
+  .ga-loading-spinner.delayed-load
+    color red
+    font-size 12px
+    width 28px
+    top 1px
+    left 8px
   .input-sm
     height 26px
     padding 3px 6px
@@ -140,6 +152,16 @@
   .ga-section-group
     border-top 1px solid #DDD
     margin-top 3px
+
+@keyframes finalpulse
+  0%
+    opacity 0
+  96%
+    opacity 0
+  98%
+    opacity 1
+  100%
+    opacity 0
 
 .ga-results-ui
   right 0

--- a/server/geoapp.py
+++ b/server/geoapp.py
@@ -664,6 +664,8 @@ class GeoAppResource(girder.api.rest.Resource):
                 result = accessObj.find(
                     params, limit, offset, sort, fields, **kwargs)
                 if result is None:
+                    # This error code may not get to the client because we are
+                    # using a generator function
                     cherrypy.response.status = 500
                     raise StopIteration
                 result['datacount'] = len(result.get('data', []))


### PR DESCRIPTION
Indicate the state of polling so that you can tell the web page is still live.

Fix how text searches are scored in elasticsearch.

Restart polled queries if the server is unreachable for some reason.

Improve handling elasticsearch timeouts.

Improve documentation on elasticsearch configuration.

Fix an exception that was thrown when the server restarted and then a poll request was made from the client.

Updated geojs to the latest master.
