### PR TITLE
Add support for user_id and user_name queries.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -224,7 +224,10 @@ geoapp.views.ControlsView = geoapp.View.extend({
      * @param speed: the number of milliseconds to take to pan the map.
      */
     finalizeInit: function (settings, speed) {
-        geoapp.map.fitBounds(geoapp.getQuerySection(settings, 'map'), speed);
+        var bounds = geoapp.getQuerySection(settings, 'map');
+        if (!$.isEmptyObject(bounds)) {
+            geoapp.map.fitBounds(bounds, speed);
+        }
         geoapp.dataLoaders.instagram.routeSettings(
             geoapp.getQuerySection(settings, 'results'));
         geoapp.graph.graphsFromNavigation(
@@ -258,6 +261,9 @@ geoapp.views.ControlsView = geoapp.View.extend({
                 return;
             }
             var params = geoapp.getQuerySection(settings, section);
+            if ($.isEmptyObject(params)) {
+                return;
+            }
             _.each(current, function (value, id) {
                 if (value !== (params[id] || '')) {
                     view.setControlValue(baseSelector + id, params[id] || '');
@@ -328,6 +334,9 @@ geoapp.views.ControlsView = geoapp.View.extend({
                 view.usedInitialSettings = true;
                 _.each(view.controlSections, function (baseSelector, section) {
                     var params = geoapp.getQuerySection(settings, section);
+                    if ($.isEmptyObject(params)) {
+                        return;
+                    }
                     _.each(params, function (value, id) {
                         if (value !== '' && value !== undefined) {
                             view.setControlValue(baseSelector + id, value);

--- a/client/templates/controlsInstagram.jade
+++ b/client/templates/controlsInstagram.jade
@@ -13,6 +13,16 @@
         type="text", placeholder="Caption substring search",
         title="Use quotes to specify exact required phrases, hashtags for exact hashtag matches, () to group clauses, | for or, and ! or - to exclude phrases.  For example, searching for 'hospital -\"hospitality\" finds hospitals but not warm welcomes.",
         taxifield="caption_search", taxitype="text")
+    .form-group.hidden
+      label(for="ga-user-name") User Name
+      input#ga-user-name.form-control.input-sm(
+        type="text", placeholder="Screen name", title="Screen name",
+        taxifield="user_name")
+    .form-group.hidden
+      label(for="ga-user-id") User ID
+      input#ga-user-id.form-control.input-sm(
+        type="text", placeholder="User ID", title="User ID",
+        taxifield="user_id")
     .form-group
       button#ga-instagram-filter.btn.btn-default.btn-sm(
           title="Load message information from the database")


### PR DESCRIPTION
This also will better preserve the current view if a partial route is loaded.

To use name_id by itself, use a query such as (host)/#?instagram-filter=ga-user-id%3D261930401
