### PR TITLE
Handle relative times.

### DIFF
--- a/client/js/controls.js
+++ b/client/js/controls.js
@@ -170,6 +170,10 @@ geoapp.views.ControlsView = geoapp.View.extend({
         },
         'show.daterangepicker': function (evt) {
             var val = this.getDateRange(evt.target, {}, 'date', true);
+            if ($(evt.target).attr('has-relative-date') === 'true') {
+                $(evt.target).data('daterangepicker').hide();
+                return false;
+            }
             $(evt.target).val(val);
         }
     },
@@ -462,25 +466,31 @@ geoapp.views.ControlsView = geoapp.View.extend({
      *   (d) 'now' - the current time.
      *
      * @param val: the value to parse.
+     * @param selector: a jquery selector to mark if the date is a relative
+     *                  value.
      * @return: a parsed moment.
      */
-    parseMomentUTC: function (val) {
+    parseMomentUTC: function (val, selector) {
         val = val.trim();
         var parts;
 
         if (val === 'now') {
             val = undefined;
+            $(selector).attr('has-relative-date', 'true');
         } else if (val.indexOf('ago') === val.length - 3 && val.length > 3) {
             parts = val.split(' ');
             val = moment.utc() - moment.duration(
                 parseFloat(parts[0]), parts[1]);
+            $(selector).attr('has-relative-date', 'true');
         } else if (val.indexOf('from now') === val.length - 8 &&
                 val.length > 8) {
             parts = val.split(' ');
             val = moment.utc() + moment.duration(
                 parseFloat(parts[0]), parts[1]);
+            $(selector).attr('has-relative-date', 'true');
         } else if (val.indexOf('-') === 0 || val.indexOf('+') === 0) {
             val = moment.utc() + parseFloat(val) * 1000;
+            $(selector).attr('has-relative-date', 'true');
         }
         return moment.utc(val);
     },
@@ -506,6 +516,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
             dbForm = 'YYYY-MM-DD HH:mm:ss',
             defaultYear = parseInt($('body').attr('defaultyear') || 2013);
 
+        $(selector).attr('has-relative-date', 'false');
         if (val === '') {
             return null;
         }
@@ -520,7 +531,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
             }
         }
         if (parts.length === 1) {
-            onlyval = this.parseMomentUTC(val);
+            onlyval = this.parseMomentUTC(val, selector);
             if (!onlyval.isValid()) {
                 onlyval = null;
             } else {
@@ -531,7 +542,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
             }
         } else {
             if (parts[0].trim() !== '') {
-                minval = this.parseMomentUTC(parts[0]);
+                minval = this.parseMomentUTC(parts[0], selector);
                 if (!minval.isValid()) {
                     minval = null;
                 } else {
@@ -542,7 +553,7 @@ geoapp.views.ControlsView = geoapp.View.extend({
                 }
             }
             if (parts[1].trim() !== '') {
-                maxval = this.parseMomentUTC(parts[1]);
+                maxval = this.parseMomentUTC(parts[1], selector);
                 if (!maxval.isValid()) {
                     maxval = null;
                 } else {


### PR DESCRIPTION
In addition to specifying date ranges as (start date) - (end date), you can specify relative dates with '+(seconds)', '-(seconds)', '(number) (units) ago', '(number) (units) from now', or 'now'.  For instance, '+7200' is two hours from the current time, '-86400' is one day before the current time.  This could instead be expressed as '2 hours from now' and '1 day ago'.  Units are anything momentjs knows how to handle.  Numbers may be float values.
