### PR TITLE
Update demo script to retrieve Docker IPs by network name

### DIFF
--- a/utils/deploy/updatedemo.py
+++ b/utils/deploy/updatedemo.py
@@ -29,7 +29,8 @@ def getDemoList():
                 'ExposedPorts' not in data['Config']):
             continue
         if ('NetworkSettings' not in data or
-                'IPAddress' not in data['NetworkSettings']):
+                'Networks' not in data['NetworkSettings'] or
+                not data['NetworkSettings']['Networks']):
             continue
         if ('State' not in data or 'StartedAt' not in data['State']):
             continue
@@ -37,6 +38,9 @@ def getDemoList():
                for item in data['Config']['Env'] if '=' in item}
         if 'KWDEMO_KEY' not in env:
             continue
+
+        network_mode = container['HostConfig']['NetworkMode']
+
         demo = {
             'id': container['Id'],
             'started': data['State']['StartedAt'],
@@ -45,7 +49,7 @@ def getDemoList():
             'desc': env.get('KWDEMO_DESC', ''),
             'url': env.get('KWDEMO_SRCURL', ''),
             'img': env.get('KWDEMO_IMG', ''),
-            'ip': data['NetworkSettings']['IPAddress'],
+            'ip': data['NetworkSettings']['Networks'][network_mode]['IPAddress'],
             'ready': env.get('KWDEMO_READY', ''),
             'ports': []
         }


### PR DESCRIPTION
@manthey Lazily copying my PR text from demodock to here:

> The IP address has traditionally been accessed through /NetworkSettings/IPAddress. Docker 1.8 introduced docker networks which provides access to the network(s) a container is a part of and their IP addresses at /NetworkSettings/Networks/$network/IPAddress where $network is /HostConfig/NetworkMode.  
> In my small amount of testing, NetworkMode was always set (defaulting to bridge) and the Networks array was present. So this method should supplant the original cleanly, however I wasn't able to find any formal documentation denoting the existence of keys in the inspect output.  
> Docker also has the ability to have a container associated with multiple networks, in which case I'm not sure how this code will function. Ideally we would inspect how docker-machine ip handles cases such as these.
